### PR TITLE
fix Binding a socket to all network interfaces could lead to CVE-2018-1281

### DIFF
--- a/slc/component/sdk-content/wifi-sdk/resources/scripts/SSL_tx_throughput.py
+++ b/slc/component/sdk-content/wifi-sdk/resources/scripts/SSL_tx_throughput.py
@@ -34,7 +34,7 @@ def ssl_tx():
 
 
 server_socket = socket(AF_INET, SOCK_STREAM)
-server_socket.bind(('0.0.0.0', 443))
+server_socket.bind(('192.168.1.100', 443))  # Replace with the specific IP address of the server
 server_socket.listen(10)
 
 # Choose the appropriate protocol based on the Python version


### PR DESCRIPTION
https://github.com/SiliconLabsSoftware/matter_extension/blob/837a2f2f08c55dff4468cb487af632d2fc3b0b6f/slc/component/sdk-content/wifi-sdk/resources/scripts/SSL_tx_throughput.py#L37-L37

fix the issue the socket should be bound to a specific IP address instead of `0.0.0.0`. This requires identifying the appropriate IP address for the server's network interface. If the IP address is not hardcoded, it can be passed as a configuration parameter or determined dynamically. For this fix, we will assume the IP address is known and replace `0.0.0.0` with a specific IP address (e.g., `192.168.1.100`).

Sockets can be used to communicate with other machines on a network. You can use the (IP address, port) pair to define the access restrictions for the socket you create. When using the built-in Python `socket` module (for instance, when building a message sender service or an FTP server data transmitter), one has to bind the port to some interface. When you bind the port to all interfaces using 0.0.0.0 as the IP address, you essentially allow it to accept connections from any IPv4 address provided that it can get to the socket via routing. Binding to all interfaces is therefore associated with security risks.

## POC
two sockets are insecure because they are bound to all interfaces; one through the `0.0.0.0` notation and another one through an empty string `''`.

```py
import socket

# binds to all interfaces, insecure
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
s.bind(('0.0.0.0', 31137))

# binds to all interfaces, insecure
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
s.bind(('', 4040))

# binds only to a dedicated interface, secure
s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
s.bind(('84.68.10.12', 8080))
```
## References
[Socket families](https://docs.python.org/3/library/socket.html#socket-families).
[Socket Programming HOWTO](https://docs.python.org/3.7/howto/sockets.html).
[CVE-2018-1281 Detail](https://nvd.nist.gov/vuln/detail/CVE-2018-1281).
[CWE-200](https://cwe.mitre.org/data/definitions/200.html).