### PR TITLE
MATTER-4990: Feature/use docker tools

### DIFF
--- a/.github/actions/install-tools/action.yaml
+++ b/.github/actions/install-tools/action.yaml
@@ -11,34 +11,7 @@ runs:
         unzip zap-linux-x64.zip -d /opt/silabs/zap-linux-x64
         rm zap-linux-x64.zip
 
-    - name: Install Simplicity Commander
-      shell: bash
-      run: |
-        wget https://www.silabs.com/documents/public/software/SimplicityCommander-Linux.zip
-        unzip SimplicityCommander-Linux.zip -d /opt/silabs/simplicity-commander
-        rm SimplicityCommander-Linux.zip
-        FILE=$(find /opt/silabs/simplicity-commander/ -name "*Commander_linux_x86_64*")
-        if [ -n "$FILE" ]; then
-          echo "$FILE"
-          tar -xjvf "$FILE" -C /opt/silabs/simplicity-commander
-        else
-          echo "File not found"
-        fi
-
-    - name: Install zip
-      shell: bash
-      run: |
-        apt-get update && apt-get install -y zip
-
-    - name: Install Arm GNU Toolchain (arm-none-eabi-gcc)
-      uses: carlosperate/arm-none-eabi-gcc-action@v1
-      id: arm-none-eabi-gcc-action
-      with:
-        release: '12.2.Rel1'
-
     - name: Set Environment Variables
       shell: bash
       run: |
-        echo "ARM_GCC_DIR=${{ steps.arm-none-eabi-gcc-action.outputs.path }}/.." >> $GITHUB_ENV
-        echo "POST_BUILD_EXE=/opt/silabs/simplicity-commander/commander/commander" >> $GITHUB_ENV
         echo "STUDIO_ADAPTER_PACK_PATH=/opt/silabs/zap-linux-x64" >> $GITHUB_ENV

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -24,14 +24,32 @@ jobs:
         name: ${{ inputs.platform }}-build-job
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/project-chip/chip-build-efr32:115
+            image: ghcr.io/siliconlabssoftware/matter_extension_dependencies:SiSDKv2024.12.1_WiFi_SDKv3.4.1_test_gcc_commander_zip
 
         steps:
             - name: Checkout
               uses: actions/checkout@v4
               with:
-                submodules: 'true'
-                lfs: true
+                submodules: 'false' # Do not initialize submodules automatically
+            
+            - name: Mark repository as safe for Git
+              shell: bash
+              run: |
+                git config --global --add safe.directory /__w/matter_extension/matter_extension
+           
+            - name: Initialize required submodules
+              shell: bash
+              run: |
+                git submodule update --init third_party/aws_ota_sdk
+                git submodule update --init third_party/matter_sdk
+                git submodule update --init third_party/matter_support
+                git submodule update --init third_party/mbedtls
+                git submodule update --init third_party/mqtt
+                git submodule update --init third_party/nlassert
+                git submodule update --init third_party/nlio
+                git submodule update --init third_party/QR-Code-generator
+                git submodule update --init third_party/wiseconnect-wifi-bt-sdk
+                # Skip unnecessary submodules like simplicity_sdk and wifi_sdk
 
             - name: Install tools
               uses: ./.github/actions/install-tools

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -24,7 +24,7 @@ jobs:
         name: ${{ inputs.platform }}-build-job
         runs-on: ubuntu-latest
         container:
-            image: ghcr.io/siliconlabssoftware/matter_extension_dependencies:SiSDKv2024.12.1_WiFi_SDKv3.4.1_test_gcc_commander_zip
+            image: ghcr.io/siliconlabssoftware/matter_extension_dependencies:SiSDKv2024.12.1-0_WiFi_SDKv3.4.1
 
         steps:
             - name: Checkout

--- a/slc/build.sh
+++ b/slc/build.sh
@@ -161,7 +161,7 @@ if [ ! -f "$STUDIO_ADAPTER_PACK_PATH/apack.json" ]; then
 fi
 
 if [ "$skip_gen" = false ]; then
-    slc generate -d $OUTPUT_DIR $PROJECT_FLAG $SILABS_APP_PATH --with $SILABS_BOARD $CONFIG_ARGS --generator-timeout=360 -o makefile
+    slc generate -d $OUTPUT_DIR $PROJECT_FLAG $SILABS_APP_PATH --with $SILABS_BOARD $CONFIG_ARGS --generator-timeout=500 -o makefile
     if [ $? -ne 0 ]; then
         echo "FAILED TO Generate : $SILABS_APP_PATH"
         exit 1

--- a/slc/build.sh
+++ b/slc/build.sh
@@ -102,8 +102,6 @@ if ! [ -x "$(command -v slc)" ]; then
     exit
 fi 
 
-echo "arm-gcc-dir: $ARM_GCC_DIR"
-
 if ! [ -d "$ARM_GCC_DIR" ]; then
     echo "ERROR: ARM_GCC_DIR is nil."
     exit

--- a/slc/build.sh
+++ b/slc/build.sh
@@ -31,7 +31,7 @@
 
 
 MATTER_ROOT=$( pwd -P )
-GSDK_ROOT=$MATTER_ROOT/third_party/simplicity_sdk
+: "${GSDK_ROOT:=$MATTER_ROOT/third_party/simplicity_sdk}"
 SILABS_APP_PATH=$1
 SILABS_BOARD=$2
 CONFIG_ARGS=""
@@ -102,6 +102,8 @@ if ! [ -x "$(command -v slc)" ]; then
     exit
 fi 
 
+echo "arm-gcc-dir: $ARM_GCC_DIR"
+
 if ! [ -d "$ARM_GCC_DIR" ]; then
     echo "ERROR: ARM_GCC_DIR is nil."
     exit
@@ -114,8 +116,13 @@ fi
 
 if ! [ -x "$(command -v arm-none-eabi-gcc)" ]; then
     echo "ERROR: $ARM_GCC_DIR/bin missing from PATH"
-    echo "Run export PATH='\$PATH:$ARM_GCC_DIR/bin' to add to PATH"
-    exit
+    echo "Run export PATH=\"\$PATH:$ARM_GCC_DIR/bin\" to add to PATH"
+    export PATH="$PATH:$ARM_GCC_DIR/bin"
+    # Optionally, re-check if arm-none-eabi-gcc is now available
+    if ! [ -x "$(command -v arm-none-eabi-gcc)" ]; then
+        echo "ERROR: arm-none-eabi-gcc still not found in PATH after update."
+        exit 1
+    fi
 fi
 
 if ! [ -x "$(command -v arm-none-eabi-gcc-12.2.1)" ]; then
@@ -133,9 +140,11 @@ if [ ! -L "$EXTENSION_DIR" ]; then
     ln -s $MATTER_ROOT "$EXTENSION_DIR"
 fi
 
-WISECONNECT3_DIR=$GSDK_ROOT/extension/wifi_sdk
-if [ ! -L "$WISECONNECT3_DIR" ]; then
-    ln -s $MATTER_ROOT/third_party/wifi_sdk/ "$WISECONNECT3_DIR"
+if [ -z "$WISECONNECT3_DIR" ]; then
+    WISECONNECT3_DIR="$GSDK_ROOT/extension/wifi_sdk"
+    if [ ! -L "$WISECONNECT3_DIR" ]; then
+        ln -s $MATTER_ROOT/third_party/wifi_sdk/ "$WISECONNECT3_DIR"
+    fi
 fi
 
 ThirdPartyHwDrivers_DIR=third_party/third_party_hw_drivers_extension


### PR DESCRIPTION
Use the Docker package generated by the new package flow, which includes tools. 
Update the build.sh script to use the env from Docker to trust the sisdk, extensions and tools. 
Not checking out sisdk and wifi_sdk submodules. 
[MATTER-4990](https://jira.silabs.com/browse/MATTER-4990)