### PR TITLE
set to use latest zap

### DIFF
--- a/slc/script/get_zap_version.py
+++ b/slc/script/get_zap_version.py
@@ -27,7 +27,7 @@ from pathlib import Path
 # This string should remain empty on the main branch. Update it only when a release branch is created. 
 # Coordinate with the studio team to determine the appropriate ZAP version for the release.
 # Version string example :  "v2024.08.14-nightly"
-SIMPLICITY_STUDIO_ZAP_VERSION = ""
+SIMPLICITY_STUDIO_ZAP_VERSION = "v2025.06.09"
 
 def get_zap_version():
     if SIMPLICITY_STUDIO_ZAP_VERSION:


### PR DESCRIPTION
Using the latest zap as CSA is using Zap
5.14.2025, which is failing to build the main branch, which requires Zap 6.9.2025