### PR TITLE
Add series 3 support in Github Actions CI 

### DIFF
--- a/.github/silabs-builds-sixg301.json
+++ b/.github/silabs-builds-sixg301.json
@@ -1,0 +1,16 @@
+{
+    "standard": {
+        "default": [
+            {
+                "boards": ["brd1019a","brd4407a", "brd4408a"],
+                "arguments": [""] 
+            }
+        ],
+        "zigbee-matter-light":  [
+            {
+                "boards": ["brd1019a", "brd4407a", "brd4408a"],
+                "arguments": ["--output_suffix sequential","'--with matter_zigbee_sequential;matter'"] 
+            }
+        ]
+    } 
+}

--- a/.github/workflows/dev-apps-builder.yaml
+++ b/.github/workflows/dev-apps-builder.yaml
@@ -57,6 +57,7 @@ jobs:
         with:
             example-app: "lighting-app"
             build-type: ${{ needs.set-build-type.outputs.build-type }}
+            sixg301-support: true
 
     build-air-quality-sensor-app:
         name: Build Air Quality Sensor App
@@ -122,6 +123,7 @@ jobs:
             example-app: "closure-app"
             build-type: ${{ needs.set-build-type.outputs.build-type }}
             thread-support: false
+            sixg301-support: true
 
     build-multi-sensor-app:
         name: Build Multi Sensor App
@@ -149,6 +151,7 @@ jobs:
             ncp-917-support: false
             ncp-wf200-support: false
             ncp-rs911x-support: false
+            sixg301-support: true
 
     build-performance-test-app:
         name: Build Performance Test App
@@ -177,6 +180,7 @@ jobs:
             ncp-wf200-support: false
             ncp-rs911x-support: false
             wifi-soc-support: false
+            sixg301-support: true
 
     build-bootloaders:
         name: Build Bootloaders

--- a/.github/workflows/platform-builder.yaml
+++ b/.github/workflows/platform-builder.yaml
@@ -65,7 +65,10 @@ on:
                 required: false
                 type: boolean
                 default: true
-
+            sixg301-support:
+                required: false
+                type: boolean
+                default: false
 jobs:
     mg24-build-job:
         if: ${{ inputs.thread-support && inputs.mg24-support }}
@@ -176,3 +179,13 @@ jobs:
             example-app: ${{ inputs.example-app }}
             build-type: ${{ inputs.build-type }}
             platform: siwx-soc
+    
+    sixg301-build-job:
+        if: ${{ inputs.sixg301-support }}
+        uses: ./.github/workflows/builder.yaml
+        with:
+            json-file-path: './.github/silabs-builds-sixg301.json'
+            path-to-example-app: ${{ inputs.example-app == 'zigbee-matter-light' && format('slc/solutions/{0}/series-3/{0}-bootloader.slcw', inputs.example-app) || format('slc/solutions/{0}/series-3/{0}-thread-bootloader.slcw', inputs.example-app) }}
+            example-app: ${{ inputs.example-app }}
+            build-type: ${{ inputs.build-type }}
+            platform: sixg301


### PR DESCRIPTION
Issue Link:
NOJIRA

Description of Problem/Feature:
Current github actions CI does not support series 3 boards.

Description of Fix/Solution:
Add json file for all series 3 boards to be included in github actions CI and configure build job with correct paths to reach sample apps. Default series 3 support to false, as not all apps are supported yet, and manually set to true for supported apps. 

Testing Done:
CI