### PR TITLE
Update SQA Pipeline Triggers 

### DIFF
--- a/.github/workflows/dev-apps-builder.yaml
+++ b/.github/workflows/dev-apps-builder.yaml
@@ -203,25 +203,25 @@ jobs:
                 delete-merged: true
                 pattern: "*-${{ needs.set-build-type.outputs.build-type }}"
 
-    wait-for-test-results:
-        name: Wait for Test Results
-        needs: merge-apps
-        uses: ./.github/workflows/sqa-sanity-tests.yaml
-        secrets:
-            SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
+    # wait-for-test-results:
+    #    name: Wait for Test Results
+    #    needs: merge-apps
+    #    uses: ./.github/workflows/sqa-sanity-tests.yaml
+    #    secrets:
+    #        SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
 
-    trigger-sqa-workflow:
-        name: Trigger SQA Workflow
-        needs: wait-for-test-results
-        runs-on: ubuntu-latest
-        if: ${{ startsWith(github.ref, 'refs/heads/release_') || github.ref == 'refs/heads/main' }}
-        steps:
-            - name: Trigger Workflow
-              run: |
-                  curl -X POST \
-                      -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-                      -H "Accept: application/vnd.github.v3+json" \
-                      https://api.github.com/repos/${{ github.repository }}/actions/workflows/sqa-apps-builder.yaml/dispatches \
-                      -d '{
-                          "ref": "${{ github.ref }}"
-                      }'
+    # trigger-sqa-workflow:
+    #    name: Trigger SQA Workflow
+    #    needs: wait-for-test-results
+    #    runs-on: ubuntu-latest
+    #    if: ${{ startsWith(github.ref, 'refs/heads/release_') || github.ref == 'refs/heads/main' }}
+    #    steps:
+    #        - name: Trigger Workflow
+    #          run: |
+    #              curl -X POST \
+    #                  -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+    #                  -H "Accept: application/vnd.github.v3+json" \
+    #                  https://api.github.com/repos/${{ github.repository }}/actions/workflows/sqa-apps-builder.yaml/dispatches \
+    #                  -d '{
+    #                      "ref": "${{ github.ref }}"
+    #                  }'

--- a/.github/workflows/dev-apps-builder.yaml
+++ b/.github/workflows/dev-apps-builder.yaml
@@ -203,25 +203,25 @@ jobs:
                 delete-merged: true
                 pattern: "*-${{ needs.set-build-type.outputs.build-type }}"
 
-    # wait-for-test-results:
-    #    name: Wait for Test Results
-    #    needs: merge-apps
-    #    uses: ./.github/workflows/sqa-sanity-tests.yaml
-    #    secrets:
-    #        SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
+    wait-for-test-results:
+        name: Wait for Test Results
+        needs: merge-apps
+        uses: ./.github/workflows/sqa-sanity-tests.yaml
+        secrets:
+            SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}
 
-    # trigger-sqa-workflow:
-    #    name: Trigger SQA Workflow
-    #    needs: wait-for-test-results
-    #    runs-on: ubuntu-latest
-    #    if: ${{ startsWith(github.ref, 'refs/heads/release_') || github.ref == 'refs/heads/main' }}
-    #    steps:
-    #        - name: Trigger Workflow
-    #          run: |
-    #              curl -X POST \
-    #                  -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
-    #                  -H "Accept: application/vnd.github.v3+json" \
-    #                  https://api.github.com/repos/${{ github.repository }}/actions/workflows/sqa-apps-builder.yaml/dispatches \
-    #                  -d '{
-    #                      "ref": "${{ github.ref }}"
-    #                  }'
+    trigger-sqa-workflow:
+        name: Trigger SQA Workflow
+        needs: wait-for-test-results
+        runs-on: ubuntu-latest
+        if: ${{ startsWith(github.ref, 'refs/heads/release_') || github.ref == 'refs/heads/main' }}
+        steps:
+            - name: Trigger Workflow
+              run: |
+                  curl -X POST \
+                      -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+                      -H "Accept: application/vnd.github.v3+json" \
+                      https://api.github.com/repos/${{ github.repository }}/actions/workflows/sqa-apps-builder.yaml/dispatches \
+                      -d '{
+                          "ref": "${{ github.ref }}"
+                      }'

--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -134,7 +134,7 @@ pipeline
                 }
             }
         }
-        stage('Trigger SQA Regression Pipelines')
+        stage('Trigger SQA Regression Pipelines') 
         {
             when {
                 expression { env.BRANCH_NAME.startsWith("main") || env.BRANCH_NAME.startsWith("release_") }

--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline
        }
        stage('Upload SQA Artifacts') {
             when {
-                expression { env.BRANCH_NAME.startsWith("main") || env.BRANCH_NAME.startsWith("release_") }
+                expression { env.BRANCH_NAME.startsWith("release_") }
             }
             steps {
                 script {
@@ -137,7 +137,7 @@ pipeline
         stage('Trigger SQA Regression Pipelines') 
         {
             when {
-                expression { env.BRANCH_NAME.startsWith("main") || env.BRANCH_NAME.startsWith("release_") }
+                expression {  env.BRANCH_NAME.startsWith("release_") }
             }
             steps {
                 script {

--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -114,7 +114,7 @@ pipeline
         stage('Trigger SQA Smoke Pipeline')
         {
             when {
-                expression { pr_number == null }
+                expression { env.BRANCH_NAME.startsWith("main") || env.BRANCH_NAME.startsWith("release_") }
             }
             steps {
                 script {
@@ -124,7 +124,7 @@ pipeline
        }
        stage('Upload SQA Artifacts') {
             when {
-                expression { pr_number == null }
+                expression { env.BRANCH_NAME.startsWith("main") || env.BRANCH_NAME.startsWith("release_") }
             }
             steps {
                 script {
@@ -137,7 +137,7 @@ pipeline
         stage('Trigger SQA Regression Pipelines')
         {
             when {
-                expression { pr_number == null }
+                expression { env.BRANCH_NAME.startsWith("main") || env.BRANCH_NAME.startsWith("release_") }
             }
             steps {
                 script {

--- a/jenkins_integration/artifacts/artifact_processor.py
+++ b/jenkins_integration/artifacts/artifact_processor.py
@@ -138,7 +138,7 @@ def _get_artifact_info(workflow_id):
     Raises:
         RuntimeError: If API request fails or no artifacts found
     """
-    workflow_artifact_url = f"{config.actions_runs_url}/{workflow_id}/artifacts"
+    workflow_artifact_url = f"{config.actions_runs_base_url}/{workflow_id}/artifacts"
     print(f"Fetching artifacts from URL: {workflow_artifact_url}")
     response = _make_github_api_request(workflow_artifact_url)
     artifacts_data = response.json()

--- a/jenkins_integration/config.py
+++ b/jenkins_integration/config.py
@@ -5,8 +5,8 @@ repo_name = "matter_extension"
 pr_sha_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/pulls'
 sha_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/commits?sha='
 commits_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/commits'
-actions_runs_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs'
-actions_runs_url_pr = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?event=pull_request'
+actions_runs_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?per_page=100'
+actions_runs_url_pr = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?event=pull_reques&per_page=100'
 github_auth = "Bearer " + os.environ["GITHUB_ACCESS_TOKEN"]
 github_headers = {
     'Accept': 'application/vnd.github+json',

--- a/jenkins_integration/config.py
+++ b/jenkins_integration/config.py
@@ -7,6 +7,7 @@ sha_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/commits?sha='
 commits_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/commits'
 actions_runs_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?per_page=100'
 actions_runs_url_pr = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?event=pull_request&per_page=100'
+actions_runs_base_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs'
 github_auth = "Bearer " + os.environ["GITHUB_ACCESS_TOKEN"]
 github_headers = {
     'Accept': 'application/vnd.github+json',

--- a/jenkins_integration/config.py
+++ b/jenkins_integration/config.py
@@ -6,7 +6,7 @@ pr_sha_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/pulls'
 sha_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/commits?sha='
 commits_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/commits'
 actions_runs_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?per_page=100'
-actions_runs_url_pr = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?event=pull_reques&per_page=100'
+actions_runs_url_pr = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?event=pull_request&per_page=100'
 github_auth = "Bearer " + os.environ["GITHUB_ACCESS_TOKEN"]
 github_headers = {
     'Accept': 'application/vnd.github+json',

--- a/jenkins_integration/jenkinsFunctions.groovy
+++ b/jenkins_integration/jenkinsFunctions.groovy
@@ -201,14 +201,14 @@ def trigger_sqa_pipelines(pipeline_type, commit_sha)
                     sh 'git clone ssh://git@stash.silabs.com/wmn_sqa/sqa-pipelines.git'
                     sh 'pwd && ls -al'
                     dir('sqa-pipelines') {
-                        sqaFunctions.commitToMatterSqaPipelines("slc", "smoke", "${env.BRANCH_NAME}", "${env.BUILD_NUMBER}", "${commit_sha}")
+                        sqaFunctions.commitToMatterSqaPipelines("slc", "smoke", "${env.BRANCH_NAME}", "${env.BUILD_NUMBER}")
                     }
                 } else {
                     if(env.BRANCH_NAME.startsWith("release")){
                         regression_list.each { regression_type ->
                             dir('sqa-pipelines') {
                                 try{
-                                    sqaFunctions.commitToMatterSqaPipelines("slc", "regression", "${env.BRANCH_NAME}", "${env.BUILD_NUMBER}", "${commit_sha}")
+                                    sqaFunctions.commitToMatterSqaPipelines("slc", "regression", "${env.BRANCH_NAME}", "${env.BUILD_NUMBER}")
                                 } catch (e) {
                                     unstable("Error when triggering ${regression_type}: ${e.message}")
                                     errorOccurred = true
@@ -219,7 +219,7 @@ def trigger_sqa_pipelines(pipeline_type, commit_sha)
                         regression_list_main.each { regression_type ->
                             dir('sqa-pipelines') {
                                 try{
-                                    sqaFunctions.commitToMatterSqaPipelines("slc", "regression", "${env.BRANCH_NAME}", "${env.BUILD_NUMBER}", "${commit_sha}")
+                                    sqaFunctions.commitToMatterSqaPipelines("slc", "regression", "${env.BRANCH_NAME}", "${env.BUILD_NUMBER}")
                                 } catch (e) {
                                     unstable("Error when triggering ${regression_type}: ${e.message}")
                                     errorOccurred = true


### PR DESCRIPTION
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
- When testing standard vs full build split on a test release_ branch, SQA pipeline was triggered which caused a failure.
- Ran into CI issue where API endpoint was not showing run unless adding ?per_page=100 to the URL.
- When testing release_ branch reached smoke stage, the trigger was failing

**Description of Fix/Solution:**
- Update SQA pipeline to explicitly be triggered on main and release_ branches only, rather than only when pr_number == null
- Added ?per_page=100 tag to actions_url for both branches and PRs to ensure that run is picked up in API endpoint. Updated artifact url to handle this URL change correctly.
- Removed commit_sha argument from commitToMatterSqaPipelines to fix smoke trigger, and removed main branch trigger for Upload SQA Artifacts and Trigger SQA Regression Pipelines stages as SQA artifacts are not built.

**Testing Done:**
Ran CI on test bugfix branch and test release branch:
- bugfix branch
   - [Github CI](https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/17619918017)
   - [Jenkins Result](https://jenkins-cbs-iot-matter.silabs.net/blue/organizations/jenkins/Matter%20Extension%20GitHub/detail/bugfix%2Fnew_SQA_pipeline_triggers/1/pipeline/)
- Test release branch
   - [Github CI](https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/17735851057)
   - [Jenkins Result](https://jenkins-cbs-iot-matter.silabs.net/blue/organizations/jenkins/Matter%20Extension%20GitHub/detail/release_new-test-SQA-pipelines/7/pipeline/)