### PR TITLE
NOJIRA: Implement Validate Metadata into Github workflow

### DIFF
--- a/.github/workflows/validate-metadata.yaml
+++ b/.github/workflows/validate-metadata.yaml
@@ -139,7 +139,7 @@ jobs:
           
       - name: Validate Components
         shell: bash
-        continue-on-error: true
+        continue-on-error: true # TO-DO: Set to false once work is completed to resolve validate components errors
         run: |
           set -e
           python3 -u './slc/script/validate_components.py' slc/component slc

--- a/.github/workflows/validate-metadata.yaml
+++ b/.github/workflows/validate-metadata.yaml
@@ -15,8 +15,8 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-  validate-package-field:
-    name: Validate Matter Extension Package Field
+  package-field:
+    name: Matter Extension Package Field
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -24,7 +24,7 @@ jobs:
         with:
           submodules: false 
 
-      - name: Validate Matter Extension Package Field
+      - name: Matter Extension Package Field
         shell: bash
         run: |
           set -e 
@@ -35,15 +35,14 @@ jobs:
             if [[ -f "missing_package_matter.txt" ]]; then
               echo "Packages without 'package: matter' detected"
               cat missing_package_matter.txt
-              exit 1 
             else 
               echo "Error: 'missing_package_matter.txt' does not exist, but it was expected."
               exit 1
             fi
           fi
 
-  validate-file-path-lengths:
-    name: Validate Matter Extension File Path Lengths
+  file-path-lengths:
+    name: Matter Extension File Path Lengths
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -68,12 +67,11 @@ jobs:
     - name: Stage Extension
       run: python3 slc/stage_extension.py ../staged
 
-    - name: Validate Matter Extension File Path Lengths 
+    - name: Matter Extension File Path Lengths 
       shell: bash
       working-directory: ${{ github.workspace }}/../staged/matter_extension
       run: |
         set -e 
-        pwd
         output=$(python3 -u './slc/script/file_path_length_analyzer.py' --directory . --verbose 2>&1) 
         echo "$output"
         no_warning="INFO:__main__:No file paths exceeding 240 characters were detected. Nothing will be written to the file."
@@ -81,15 +79,14 @@ jobs:
           if [[ -f "long_file_paths.txt" ]]; then
             echo "File paths exceeding 240 characters detected!"
             cat long_file_paths.txt
-            exit 1
           else
             echo "Error: 'long_file_paths.txt' does not exist, but it was expected."
             exit 1
           fi  
         fi
         
-  validate-matter-templates:
-    name: Validate Matter Templates
+  matter-templates:
+    name: Matter Templates
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -97,14 +94,14 @@ jobs:
         with:
           submodules: false 
 
-      - name: Validate Matter Templates 
+      - name: Matter Templates 
         shell: bash
         run: | 
           set -e
           python3 -u './slc/script/validate_matter_templates.py'
    
-  validate-components:
-    name: Validate Components
+  components:
+    name: Components
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/siliconlabssoftware/matter_extension_dependencies:latest
@@ -140,7 +137,7 @@ jobs:
           slc configuration --sdk ${SISDK_ROOT} -data ${SISDK_ROOT}/out/dmp_uc.data
           slc signature trust --sdk ${SISDK_ROOT}
           
-      - name: Validate Components
+      - name: Components
         shell: bash
         continue-on-error: true
         run: |

--- a/.github/workflows/validate-metadata.yaml
+++ b/.github/workflows/validate-metadata.yaml
@@ -1,0 +1,148 @@
+name: Validate Metadata
+
+on:
+  push:
+      branches:
+          - main
+          - "release_*"
+  pull_request:
+        branches:
+          - main
+          - "release_*"
+
+concurrency: 
+    group: validate-metadata-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+  validate-package-field:
+    name: Validate Matter Extension Package Field
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          submodules: false 
+
+      - name: Validate Matter Extension Package Field
+        shell: bash
+        run: |
+          set -e 
+          output=$(python3 -u './slc/script/verify_package_matter.py' --directory . --verbose 2>&1) 
+          echo "$output"
+          no_warning="INFO - All .slcc, .slcp, and .slce files contain the required strings."
+          if [[ "$output" != *"$no_warning"* ]]; then
+            if [[ -f "missing_package_matter.txt" ]]; then
+              echo "Packages without 'package: matter' detected"
+              cat missing_package_matter.txt
+              exit 1 
+            else 
+              echo "Error: 'missing_package_matter.txt' does not exist, but it was expected."
+              exit 1
+            fi
+          fi
+
+  validate-file-path-lengths:
+    name: Validate Matter Extension File Path Lengths
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v5
+      with:
+        submodules: false 
+
+    - name: Initialize required submodules
+      shell: bash
+      run: |
+        git submodule update --init \
+          third_party/aws_ota_sdk \
+          third_party/matter_sdk \
+          third_party/matter_support \
+          third_party/mbedtls \
+          third_party/mqtt \
+          third_party/nlassert \
+          third_party/nlio \
+          third_party/QR-Code-generator \
+          third_party/wiseconnect-wifi-bt-sdk
+      
+    - name: Stage Extension
+      run: python3 slc/stage_extension.py ../staged
+
+    - name: Validate Matter Extension File Path Lengths 
+      shell: bash
+      working-directory: ${{ github.workspace }}/../staged/matter_extension
+      run: |
+        set -e 
+        pwd
+        output=$(python3 -u './slc/script/file_path_length_analyzer.py' --directory . --verbose 2>&1) 
+        echo "$output"
+        no_warning="INFO:__main__:No file paths exceeding 240 characters were detected. Nothing will be written to the file."
+        if [[ "$output" != *"$no_warning"* ]]; then
+          if [[ -f "long_file_paths.txt" ]]; then
+            echo "File paths exceeding 240 characters detected!"
+            cat long_file_paths.txt
+            exit 1
+          else
+            echo "Error: 'long_file_paths.txt' does not exist, but it was expected."
+            exit 1
+          fi  
+        fi
+        
+  validate-matter-templates:
+    name: Validate Matter Templates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          submodules: false 
+
+      - name: Validate Matter Templates 
+        shell: bash
+        run: | 
+          set -e
+          python3 -u './slc/script/validate_matter_templates.py'
+   
+  validate-components:
+    name: Validate Components
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/siliconlabssoftware/matter_extension_dependencies:latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v5
+        with:
+          submodules: false 
+
+      - name: Mark Repository as Safe for Git
+        shell: bash
+        run: |
+          git config --global --add safe.directory /__w/matter_extension/matter_extension
+      - name: Initialize required submodules
+        shell: bash
+        run: |
+          git submodule update --init \
+            third_party/aws_ota_sdk \
+            third_party/matter_sdk \
+            third_party/matter_support \
+            third_party/mbedtls \
+            third_party/mqtt \
+            third_party/nlassert \
+            third_party/nlio \
+            third_party/QR-Code-generator \
+            third_party/wiseconnect-wifi-bt-sdk
+      
+      - name: Trust SDK 
+        shell: bash
+        run: |
+          set -e 
+          echo "Trusting SDK at ${SISDK_ROOT}"
+          slc configuration --sdk ${SISDK_ROOT} -data ${SISDK_ROOT}/out/dmp_uc.data
+          slc signature trust --sdk ${SISDK_ROOT}
+          
+      - name: Validate Components
+        shell: bash
+        continue-on-error: true
+        run: |
+          set -e
+          python3 -u './slc/script/validate_components.py' slc/component slc

--- a/.github/workflows/validate-metadata.yaml
+++ b/.github/workflows/validate-metadata.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   package-field:
-    name: Matter Extension Package Field
+    name: Validate Matter Extension Package Field
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -24,7 +24,7 @@ jobs:
         with:
           submodules: false 
 
-      - name: Matter Extension Package Field
+      - name: Validate Matter Extension Package Field
         shell: bash
         run: |
           set -e 
@@ -42,7 +42,7 @@ jobs:
           fi
 
   file-path-lengths:
-    name: Matter Extension File Path Lengths
+    name: Validate Matter Extension File Path Lengths
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -67,7 +67,7 @@ jobs:
     - name: Stage Extension
       run: python3 slc/stage_extension.py ../staged
 
-    - name: Matter Extension File Path Lengths 
+    - name: Validate Matter Extension File Path Lengths 
       shell: bash
       working-directory: ${{ github.workspace }}/../staged/matter_extension
       run: |
@@ -86,7 +86,7 @@ jobs:
         fi
         
   matter-templates:
-    name: Matter Templates
+    name: Validate Matter Templates
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -94,14 +94,14 @@ jobs:
         with:
           submodules: false 
 
-      - name: Matter Templates 
+      - name: Validate Matter Templates 
         shell: bash
         run: | 
           set -e
           python3 -u './slc/script/validate_matter_templates.py'
    
   components:
-    name: Components
+    name: Validate Components
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/siliconlabssoftware/matter_extension_dependencies:latest
@@ -137,7 +137,7 @@ jobs:
           slc configuration --sdk ${SISDK_ROOT} -data ${SISDK_ROOT}/out/dmp_uc.data
           slc signature trust --sdk ${SISDK_ROOT}
           
-      - name: Components
+      - name: Validate Components
         shell: bash
         continue-on-error: true
         run: |


### PR DESCRIPTION
**Issue Link:** 
NOJIRA

**Description of Problem/Feature:**
Currently Validate Metadata in Github Actions is called within dev-apps-builder, making it difficult for developers to know if a metadata validation failure has occurred when it is bundled in with build flow.

**Description of Fix/Solution:**
Implement Validate Metadata into its own workflow.

**Testing Done:**
CI