### PR TITLE
Combining CMP files

### DIFF
--- a/slc/component/matter-core-sdk/encode_decode.slcc
+++ b/slc/component/matter-core-sdk/encode_decode.slcc
@@ -7,10 +7,10 @@ define:
 description: encode_decode
 id: encode_decode
 include:
--   path: third_party/matter_sdk/src/app/data-model
+-   path: third_party/matter_sdk/src/app/
     file_list:
-    -   path: StructDecodeIterator.h
-    -   path: WrappedStructEncoder.h
+    -   path: data-model/StructDecodeIterator.h
+    -   path: data-model/WrappedStructEncoder.h
 label: encode_decode
 package: matter
 provides:

--- a/slc/component/matter-core-sdk/libchipappserver.slcc
+++ b/slc/component/matter-core-sdk/libchipappserver.slcc
@@ -29,6 +29,7 @@ include:
   - path: third_party/matter_sdk/src/nfc
     file_list:
       - path: NFCReaderTransport.h
+      - path: NFCTag.h
 label: libchipappserver
 package: matter
 provides:

--- a/slc/component/matter-core-sdk/libchipdatamodel.slcc
+++ b/slc/component/matter-core-sdk/libchipdatamodel.slcc
@@ -91,15 +91,15 @@ include:
     -   path: AttributeAccessInterfaceRegistry.h
     -   path: AttributeReportBuilder.cpp
     -   path: AttributeValueEncoder.cpp
-  - path: third_party/matter_sdk/src/app/persistence
+  - path: third_party/matter_sdk/src/app
     file_list:
-    -   path: AttributePersistenceProviderInstance.h
-    -   path: DefaultAttributePersistenceProvider.h
-    -   path: DeferredAttributePersistenceProvider.h
-    -   path: AttributePersistenceProvider.h
-    -   path: PascalString.h
-    -   path: String.h
-    -   path: AttributePersistence.h
+    -   path: persistence/AttributePersistenceProviderInstance.h
+    -   path: persistence/DefaultAttributePersistenceProvider.h
+    -   path: persistence/DeferredAttributePersistenceProvider.h
+    -   path: persistence/AttributePersistenceProvider.h
+    -   path: persistence/PascalString.h
+    -   path: persistence/String.h
+    -   path: persistence/AttributePersistence.h
 label: libchipdatamodel
 package: matter
 provides:

--- a/slc/sample-app/lighting-app/efr32/lighting-app-thread.slcp
+++ b/slc/sample-app/lighting-app/efr32/lighting-app-thread.slcp
@@ -138,7 +138,7 @@ source:
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src
-  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/ZclCallbacks.cpp
+  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/MatterDMCallbacks.cpp
     directory: src
 
 define:

--- a/slc/sample-app/lighting-app/siwx917/lighting-app-917-soc.slcp
+++ b/slc/sample-app/lighting-app/siwx917/lighting-app-917-soc.slcp
@@ -173,7 +173,7 @@ source:
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src
-  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/ZclCallbacks.cpp
+  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/MatterDMCallbacks.cpp
     directory: src
 
 define:

--- a/slc/sample-app/zigbee-matter-light/efr32/zigbee-matter-light.slcp
+++ b/slc/sample-app/zigbee-matter-light/efr32/zigbee-matter-light.slcp
@@ -266,7 +266,7 @@ source:
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src
-  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/ZclCallbacks.cpp
+  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/MatterDMCallbacks.cpp
     directory: src
 
 include:

--- a/slc/sample-app/zigbee-matter-light/efr32/zigbee-matter-light.slcp
+++ b/slc/sample-app/zigbee-matter-light/efr32/zigbee-matter-light.slcp
@@ -260,15 +260,17 @@ config_file:
     condition: [matter_ble_dmp_test]
 
 source:
-  - path: ../../../../third_party/matter_sdk/examples/zigbee-matter-light/silabs/src/AppTask.cpp
+  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/AppTask.cpp
     directory: src
-  - path: ../../../../third_party/matter_sdk/examples/zigbee-matter-light/silabs/src/MatterDMCallbacks.cpp
+  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/LightingManager.cpp
     directory: src
-  - path: ../../../../third_party/matter_sdk/examples/zigbee-matter-light/silabs/src/LightingManager.cpp
+  - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
+    directory: src
+  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/ZclCallbacks.cpp
     directory: src
 
 include:
-  - path: ../../../../third_party/matter_sdk/examples/zigbee-matter-light/silabs/include
+  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/include
     file_list:
       - path: AppConfig.h
       - path: AppEvent.h

--- a/slc/sample-app/zigbee-matter-light/efr32/zigbee-matter-light.slcp
+++ b/slc/sample-app/zigbee-matter-light/efr32/zigbee-matter-light.slcp
@@ -277,6 +277,8 @@ include:
       - path: AppTask.h
       - path: CHIPProjectConfig.h
       - path: LightingManager.h
+      - path: ZigbeeCMPConfig.h
+      - path: ZigbeeSequentialConfig.h
     directory: include
 post_build:
   profile: application


### PR DESCRIPTION
**Jira Issue Number:**
https://jira.silabs.com/browse/MATTER-5169
**Description of Problem/Feature:**
CMP files are only available for the zigbee matter light, we need to move them to a common location where it makes sense to reduce dupplication when adding more CMP apps.

**Description of Fix/Solution:**
Removed the Zigbee Matter Light Sources and put Zigbee specific calls into common or lighting app sources to reduce code duplication and to have Zigbee data model init accessible from other cmp apps.
**Testing Done:**
Build flash and commission CMP and Lighting apps with the new file structure.
**Associated Matter SDK commit:**
https://github.com/SiliconLabsSoftware/matter_sdk/pull/602