### PR TITLE
Add thread support for closure app

### DIFF
--- a/.github/workflows/dev-apps-builder.yaml
+++ b/.github/workflows/dev-apps-builder.yaml
@@ -118,7 +118,6 @@ jobs:
         with:
             example-app: "closure-app"
             build-type: ${{ needs.set-build-type.outputs.build-type }}
-            thread-support: false
 
     build-multi-sensor-app:
         name: Build Multi Sensor App


### PR DESCRIPTION
**Issue Link:** 
NOJIRA

**Description of Problem/Feature:**
Closure app is not being built for Thread boards 

**Description of Fix/Solution:**
Remove lack of thread support for closure app 

**Testing Done:**
CI
Manually built closure app for brd2704a (only board that doesn't build closure app in mgm24-internal family) to ensure successful project build. 