### PR TITLE
Update file path length analyzer script to handle success validation

### DIFF
--- a/.github/workflows/validate-metadata.yaml
+++ b/.github/workflows/validate-metadata.yaml
@@ -73,9 +73,6 @@ jobs:
       working-directory: ${{ github.workspace }}/../staged/matter_extension
       run: |
         python3 -u './slc/script/file_path_length_analyzer.py' --directory . --verbose --ci
-        if [[ $? -ne 0 ]]; then
-          echo "File paths exceeding 240 characters detected!"
-        fi
         
   matter-templates:
     name: Validate Matter Templates

--- a/.github/workflows/validate-metadata.yaml
+++ b/.github/workflows/validate-metadata.yaml
@@ -72,7 +72,6 @@ jobs:
       shell: bash
       working-directory: ${{ github.workspace }}/../staged/matter_extension
       run: |
-        set -e
         python3 -u './slc/script/file_path_length_analyzer.py' --directory . --verbose --ci
         if [[ $? -ne 0 ]]; then
           echo "File paths exceeding 240 characters detected!"

--- a/.github/workflows/validate-metadata.yaml
+++ b/.github/workflows/validate-metadata.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           submodules: false 
 
+      # TO-DO: Update to use script output when release_2.7 is merged to main 
       - name: Validate Matter Extension Package Field
         shell: bash
         run: |
@@ -67,22 +68,14 @@ jobs:
     - name: Stage Extension
       run: python3 slc/stage_extension.py ../staged
 
-    - name: Validate Matter Extension File Path Lengths 
+    - name: Validate Matter Extension File Path Lengths
       shell: bash
       working-directory: ${{ github.workspace }}/../staged/matter_extension
       run: |
-        set -e 
-        output=$(python3 -u './slc/script/file_path_length_analyzer.py' --directory . --verbose 2>&1) 
-        echo "$output"
-        no_warning="INFO:__main__:No file paths exceeding 240 characters were detected. Nothing will be written to the file."
-        if [[ "$output" != *"$no_warning"* ]]; then
-          if [[ -f "long_file_paths.txt" ]]; then
-            echo "File paths exceeding 240 characters detected!"
-            cat long_file_paths.txt
-          else
-            echo "Error: 'long_file_paths.txt' does not exist, but it was expected."
-            exit 1
-          fi  
+        set -e
+        python3 -u './slc/script/file_path_length_analyzer.py' --directory . --verbose --ci
+        if [[ $? -ne 0 ]]; then
+          echo "File paths exceeding 240 characters detected!"
         fi
         
   matter-templates:

--- a/slc/script/file_path_length_analyzer.py
+++ b/slc/script/file_path_length_analyzer.py
@@ -124,8 +124,10 @@ def main():
     # CI mode: exit with status 0 on success, 1 on failure
     if args.ci:
         if grouped_paths:
+            print("File paths exceeding 240 characters detected!")
             sys.exit(1)
         else:
+            print("No file paths exceeding 240 characters were detected. Success.")
             sys.exit(0)
 
 if __name__ == "__main__":

--- a/slc/script/file_path_length_analyzer.py
+++ b/slc/script/file_path_length_analyzer.py
@@ -28,6 +28,7 @@ import os
 import sys
 import argparse
 import logging
+import sys
 from io import BufferedWriter
 
 # The prefix represents a base file path commonly found on Windows machines. 
@@ -89,6 +90,11 @@ def main():
         action="store_true",
         help="Enable detailed output."
     )
+    parser.add_argument(
+        "--ci",
+        action="store_true",
+        help="CI mode: exit with status 0 on success, 1 on failure"
+    )
     args = parser.parse_args()
 
     # Configure logging level based on verbosity
@@ -113,6 +119,13 @@ def main():
     write_long_file_paths(grouped_paths, output_file)
     if grouped_paths:
         logger.info(f"File paths are calculated by adding a prefix: {prefix}, of length {len(prefix)} to the paths")
+
+    # CI mode: exit with status 0 on success, 1 on failure
+    if args.ci:
+        if grouped_paths:
+            sys.exit(1)
+        else:
+            sys.exit(0)
 
 if __name__ == "__main__":
     main()

--- a/slc/script/file_path_length_analyzer.py
+++ b/slc/script/file_path_length_analyzer.py
@@ -109,16 +109,17 @@ def main():
 
     grouped_paths = count_file_path_lengths(directory, prefix, args.verbose)
 
-    if grouped_paths:
-        # Log grouped counts
-        logger.info("Updated file path length counts grouped in blocks of 10:")
-        for group, paths in sorted(grouped_paths.items()):
-            logger.info(f"{group}-{group+9}: {len(paths)}")
+    if not args.ci:
+        if grouped_paths:
+            # Log grouped counts
+            logger.info("Updated file path length counts grouped in blocks of 10:")
+            for group, paths in sorted(grouped_paths.items()):
+                logger.info(f"{group}-{group+9}: {len(paths)}")
 
-    # Write long file paths to a file
-    write_long_file_paths(grouped_paths, output_file)
-    if grouped_paths:
-        logger.info(f"File paths are calculated by adding a prefix: {prefix}, of length {len(prefix)} to the paths")
+        # Write long file paths to a file
+        write_long_file_paths(grouped_paths, output_file)
+        if grouped_paths:
+            logger.info(f"File paths are calculated by adding a prefix: {prefix}, of length {len(prefix)} to the paths")
 
     # CI mode: exit with status 0 on success, 1 on failure
     if args.ci:

--- a/this_is_a_test_file_with_a_long_name_to_trigger_the_file_path_length_analyzer_ci_failure_and_make_sure_the_script_detects_long_paths_and_fails_the_github_action_as_expected_for_testing_purposes_abcdefghij_1234567890_extra_padding_to_reach_240.txt
+++ b/this_is_a_test_file_with_a_long_name_to_trigger_the_file_path_length_analyzer_ci_failure_and_make_sure_the_script_detects_long_paths_and_fails_the_github_action_as_expected_for_testing_purposes_abcdefghij_1234567890_extra_padding_to_reach_240.txt
@@ -1,0 +1,1 @@
+# Testing file

--- a/this_is_a_test_file_with_a_long_name_to_trigger_the_file_path_length_analyzer_ci_failure_and_make_sure_the_script_detects_long_paths_and_fails_the_github_action_as_expected_for_testing_purposes_abcdefghij_1234567890_extra_padding_to_reach_240.txt
+++ b/this_is_a_test_file_with_a_long_name_to_trigger_the_file_path_length_analyzer_ci_failure_and_make_sure_the_script_detects_long_paths_and_fails_the_github_action_as_expected_for_testing_purposes_abcdefghij_1234567890_extra_padding_to_reach_240.txt
@@ -1,0 +1,1 @@
+# Testing file 

--- a/this_is_a_test_file_with_a_long_name_to_trigger_the_file_path_length_analyzer_ci_failure_and_make_sure_the_script_detects_long_paths_and_fails_the_github_action_as_expected_for_testing_purposes_abcdefghij_1234567890_extra_padding_to_reach_240.txt
+++ b/this_is_a_test_file_with_a_long_name_to_trigger_the_file_path_length_analyzer_ci_failure_and_make_sure_the_script_detects_long_paths_and_fails_the_github_action_as_expected_for_testing_purposes_abcdefghij_1234567890_extra_padding_to_reach_240.txt
@@ -1,1 +1,0 @@
-# Testing file 

--- a/this_is_a_test_file_with_a_long_name_to_trigger_the_file_path_length_analyzer_ci_failure_and_make_sure_the_script_detects_long_paths_and_fails_the_github_action_as_expected_for_testing_purposes_abcdefghij_1234567890_extra_padding_to_reach_240.txt
+++ b/this_is_a_test_file_with_a_long_name_to_trigger_the_file_path_length_analyzer_ci_failure_and_make_sure_the_script_detects_long_paths_and_fails_the_github_action_as_expected_for_testing_purposes_abcdefghij_1234567890_extra_padding_to_reach_240.txt
@@ -1,1 +1,0 @@
-# Testing file


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Currently in Validate Metadata workflow, the output of the file path length analyzer is handled by string validation. This means that if the script output changes, we would need to update the workflow file to handle this adding extra maintenance.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Update `file_path_length_analyzer.py` to have a --ci build flag, where we return 0 on success and 1 on failure. On failure, the script will throw a warning for each problematic file path so user can see these in Github Actions UI.
Kept print based success message as a legacy support for now. 

Note that in main branch, `verify_package_matter` job has the same issue. This script has been updated on release_2.7 branch to resolve this. This cannot be implemented in Github Actions yet, as new implementation of this script will fail as code has not been pulled into `main` to add `vendor:silabs` tag. Added comment to [MATTER-5488](https://jira.silabs.com/browse/MATTER-5488) to update the package field workflow file once these changes are pulled into main. 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI and local testing of script for desired behavior 
CI for testing commit with long file path: https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/17983272891/job/51154806582#step:5:1