### PR TITLE
Fix trigger sqa pipelines stage to use proper build number and update sanity test execution to use new test suite convention

### DIFF
--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -6,6 +6,7 @@ def run_number = ""
 def workflow_id = ""
 def pr_number = ""
 def bypass_send_results_gh = ""
+def formatted_build_number = ""
 pipeline
 {
     agent { node { label 'Build-Farm-Large' } }
@@ -49,7 +50,7 @@ pipeline
                     } else {
                         branch_name = env.BRANCH_NAME
                     }
-                    def formatted_build_number = "${workflow_id}.${run_number}"
+                    formatted_build_number = "${workflow_id}.${run_number}"
                     parallelNodes['MG24 Lighting-App'] = {
                         pipelineFunctions.actionWithRetry {
                             failed_tests_mg24 = pipelineFunctions.execute_sanity_tests(
@@ -120,7 +121,7 @@ pipeline
             }
             steps {
                 script {
-                    pipelineFunctions.trigger_sqa_pipelines("smoke", run_number)
+                    pipelineFunctions.trigger_sqa_pipelines("smoke", formatted_build_number)
                 }
             }
        }
@@ -143,7 +144,7 @@ pipeline
             }
             steps {
                 script {
-                    pipelineFunctions.trigger_sqa_pipelines("regression", commit_sha)
+                    pipelineFunctions.trigger_sqa_pipelines("regression", formatted_build_number)
                 }
             }
        }

--- a/jenkins_integration/jenkinsFunctions.groovy
+++ b/jenkins_integration/jenkinsFunctions.groovy
@@ -190,7 +190,7 @@ def parse_test_results_failures(output) {
 }
 
 // TODO Verify if the pipelines are correct
-def trigger_sqa_pipelines(pipeline_type, run_number)
+def trigger_sqa_pipelines(pipeline_type, formatted_build_number)
 {
     if(sqaFunctions.isProductionJenkinsServer())
     {
@@ -203,14 +203,14 @@ def trigger_sqa_pipelines(pipeline_type, run_number)
                     sh 'git clone ssh://git@stash.silabs.com/wmn_sqa/sqa-pipelines.git'
                     sh 'pwd && ls -al'
                     dir('sqa-pipelines') {
-                        sqaFunctions.commitToMatterSqaPipelines("slc", "smoke", "${env.BRANCH_NAME}", "${run_number}")
+                        sqaFunctions.commitToMatterSqaPipelines("slc", "smoke", "${env.BRANCH_NAME}", "${formatted_build_number}")
                     }
                 } else {
                     if(env.BRANCH_NAME.startsWith("release")){
                         regression_list.each { regression_type ->
                             dir('sqa-pipelines') {
                                 try{
-                                    sqaFunctions.commitToMatterSqaPipelines("slc", "regression", "${env.BRANCH_NAME}", "${run_number}")
+                                    sqaFunctions.commitToMatterSqaPipelines("slc", "regression", "${env.BRANCH_NAME}", "${formatted_build_number}")
                                 } catch (e) {
                                     unstable("Error when triggering ${regression_type}: ${e.message}")
                                     errorOccurred = true
@@ -221,7 +221,7 @@ def trigger_sqa_pipelines(pipeline_type, run_number)
                         regression_list_main.each { regression_type ->
                             dir('sqa-pipelines') {
                                 try{
-                                    sqaFunctions.commitToMatterSqaPipelines("slc", "regression", "${env.BRANCH_NAME}", "${run_number}")
+                                    sqaFunctions.commitToMatterSqaPipelines("slc", "regression", "${env.BRANCH_NAME}", "${formatted_build_number}")
                                 } catch (e) {
                                     unstable("Error when triggering ${regression_type}: ${e.message}")
                                     errorOccurred = true


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA (NO MERGE YET)
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
The current main branch triggers the smoke pipeline on SQA side, however it has not been updated to use the GitHub Workflow number when updating the pipeline, which then causes the smoke pipeline to fail.
Some changes were also done on UTF side on how tests are collected, which means we need to add the -m argument (marker) and use the matter type to properly collect tests.
<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Use the run_number instead of env.BUILD_NUMBER. env.BUILD_NUMBER corresponds to the Jenkins build number, which is not used anymore to identify builds.
Use -m in the pytest command to properly run tests.
<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Run CI.