### PR TITLE
Adding Dual Stack lock example slcp with BLE enable on efr32

### DIFF
--- a/slc/apps/lock-app/wifi/lock-app-917-ncp-dual-stack.slcp
+++ b/slc/apps/lock-app/wifi/lock-app-917-ncp-dual-stack.slcp
@@ -1,0 +1,182 @@
+
+project_name: lock-app-917-ncp-dual-stack
+label: Matter Lock WiFi (NCP dual stack)
+description: >
+  Matter Lock App For WiFi with BLE on NCP (dual stack: WiFi + BLE on SiWx917)
+quality: production
+package: matter
+
+sdk_extension:
+  - id: matter
+    version: "2.8.0"
+    vendor: silabs
+  - id: wiseconnect3_sdk
+    version: "4.0.0"
+    vendor: silabs
+
+component:
+  - id: device_init
+  - id: sl_main
+  - id: matter_buttons
+  - id: matter_leds
+
+  - id: matter
+  - id: matter_platform_mg
+  - id: matter_ble
+  - id: matter_ota_support
+  - id: matter_crypto
+  - id: matter_efr32_ncp
+  - id: matter_wifi
+  - id: siwx917_ncp
+  - id: matter_lock
+  - id: app_common
+  - id: matter_provision_default
+
+  - id: mbedtls_pki_aws
+    condition: [matter_aws]
+  - id: mbedtls_entropy_default_aws
+    condition: [matter_aws]
+  - id: psa_crypto_tls12_prf
+    condition: [matter_aws]
+
+  - id: matter_access_control
+  - id: matter_administrator_commissioning
+  - id: matter_basic_information
+  - id: matter_descriptor
+  - id: matter_diagnostic_logs
+  - id: matter_door_lock
+  - id: matter_ethernet_network_diagnostics
+  - id: matter_fixed_label
+  - id: matter_general_commissioning
+  - id: matter_general_diagnostics
+  - id: matter_group_key_mgmt
+  - id: matter_groups
+  - id: matter_identify
+  - id: matter_localization_configuration
+  - id: matter_network_commissioning
+  - id: matter_operational_credentials
+  - id: matter_ota_requestor
+  - id: matter_power_source_configuration
+  - id: matter_power_source
+  - id: matter_software_diagnostics
+  - id: matter_thread_network_diagnostics
+
+  - id: matter_time_format_localization
+  - id: matter_user_label
+  - id: matter_unit_localization
+  - id: matter_wifi_network_diagnostics
+  # Override configuration for JTAG use
+  - id: matter_configuration_over_swo
+  - id: matter_segger_rtt
+
+  - id: matter_shell
+  - id: matter_icd_core
+  - id: matter_test_event_trigger
+  - id: matter_icd_management
+  - id: matter_log_uart
+  - id: matter_lwip
+
+  - id: wifi_resources
+  - id: wifi
+  - id: basic_network_config_manager
+  - id: sl_si91x_basic_buffers
+  - id: sl_si91x_wireless
+
+config_file:
+  - path: ../../../../third_party/matter_sdk/examples/lock-app/silabs/data_model/lock-app.zap
+    directory: common
+    file_id: zap_config
+  - path: ../../../../provision.mattpconf
+    directory: provision
+    file_id: provision_config
+
+include:
+  - path: ../../../../third_party/matter_sdk/examples/lock-app/silabs/include
+    file_list:
+      - path: AppConfig.h
+      - path: AppEvent.h
+      - path: AppTask.h
+      - path: LockManager.h
+      - path: CHIPProjectConfig.h
+    directory: include
+
+source:
+  - path: ../../../../third_party/matter_sdk/examples/lock-app/silabs/src/AppTask.cpp
+    directory: src
+  - path: ../../../../third_party/matter_sdk/examples/lock-app/silabs/src/LockManager.cpp
+    directory: src
+  - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
+    directory: src
+  - path: ../../../../third_party/matter_sdk/examples/lock-app/silabs/src/DataModelCallbacks.cpp
+    directory: src
+
+define:
+  - name: CHIP_CRYPTO_PLATFORM
+    value: "1"
+  - name: _WANT_REENT_SMALL
+    value: "1"
+  - name: IS_DEMO_LOCK
+    value: "1"
+  - name: NVM3_DEFAULT_NVM_SIZE
+    value: "40960"
+  - name: NVM3_DEFAULT_MAX_OBJECT_SIZE
+    value: "4092"
+configuration:
+  - name: SL_SPIDRV_EXP_BITRATE
+    value: "10000000"
+  - name: SL_SPIDRV_EUSART_EXP_BITRATE
+    value: "10000000"
+  - name: SL_POWER_MANAGER_LOWEST_EM_ALLOWED
+    value: "1"
+  - name: SL_PSA_KEY_USER_SLOT_COUNT
+    value: "21"
+  - name: SL_POWER_MANAGER_CONFIG_VOLTAGE_SCALING_FAST_WAKEUP
+    value: "1"
+  - name: SL_STACK_SIZE
+    value: "4608"
+  - name: SL_BT_RTOS_EVENT_HANDLER_STACK_SIZE
+    value: "1536"
+    unless: [device_series_3]
+  - name: SL_BT_RTOS_EVENT_HANDLER_STACK_SIZE
+    value: "1856"
+    condition: [device_series_3]
+  # Default ICD configurations
+  - name: SL_IDLE_MODE_DURATION_S
+    value: "600"
+  - name: SL_ACTIVE_MODE_DURATION_MS
+    value: "0"
+  - name: SL_ACTIVE_MODE_THRESHOLD
+    value: "0"
+  - name: SL_TRANSPORT_IDLE_INTERVAL
+    value: "3000"
+
+  - name: CHIP_CONFIG_SYNCHRONOUS_REPORTS_ENABLED
+    value: "1"
+  - name: CHIP_CONFIG_SUBSCRIPTION_TIMEOUT_RESUMPTION
+    value: "0"
+  - name: SL_MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS
+    value: 1
+
+toolchain_settings:
+  - option: cxx_standard
+    value: gnu++17
+template_contribution:
+  - name: memory_ram_start
+    value: 0x20000000
+  - name: memory_ram_size
+    value: 0x42000
+
+readme:
+  - path: ./README_WiFi.md
+ui_hints:
+  highlight:
+    - path: README_WiFi.md
+      focus: false
+
+tag:
+  - hardware:component:led:2+
+post_build:
+  profile: application
+
+other_file:
+  - path: ../../../image/qr_code_img.png

--- a/slc/apps/lock-app/wifi/lock-app-917-ncp-dual-stack.slcp
+++ b/slc/apps/lock-app/wifi/lock-app-917-ncp-dual-stack.slcp
@@ -2,7 +2,7 @@
 project_name: lock-app-917-ncp-dual-stack
 label: Matter Lock WiFi (NCP dual stack)
 description: >
-  Matter Lock App For WiFi with BLE on NCP (dual stack: WiFi + BLE on SiWx917)
+  Matter Lock App For WiFi on NCP with BLE on host (Dual stack: IPV6 on EFR32, IPV4 on SiWx917)
 quality: production
 package: matter
 

--- a/slc/apps/lock-app/wifi/lock-app-917-ncp-dual-stack.slcp
+++ b/slc/apps/lock-app/wifi/lock-app-917-ncp-dual-stack.slcp
@@ -11,7 +11,7 @@ sdk_extension:
     version: "2.8.0"
     vendor: silabs
   - id: wiseconnect3_sdk
-    version: "4.0.0"
+    version: "4.1.0"
     vendor: silabs
 
 component:

--- a/slc/apps/lock-app/wifi/lock-app-917-ncp-dual-stack.slcw
+++ b/slc/apps/lock-app/wifi/lock-app-917-ncp-dual-stack.slcw
@@ -1,0 +1,13 @@
+label: lock-app-917-ncp-dual-stack
+quality: production
+package: matter
+description: Matter solution containing both a Matter bootloader and Lock over WiFi (NCP dual stack) Example
+project:
+  - path: ./lock-app-917-ncp-dual-stack.slcp
+    id: application
+    output: lock-app-917-ncp-dual-stack
+  - path: ../../bootloaders/bootloader-storage-internal-single-series-2/bootloader-storage-internal-single-series-2.slcp
+    id: bootloader
+    output: matter-bootloader
+post_build:
+  path: ../../../postbuild/ws_default_application_bootloader.slpb

--- a/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
+++ b/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
@@ -2,7 +2,7 @@ id: siwx917_ncp
 package: matter
 label: SiWx917 NCP Extension
 description: >
-  Adds support for the HAL and WiFi Driver layer for SiWx917 NCP devices
+  Adds support for the HAL ,BLE and WiFi Driver layer for SiWx917 NCP devices
 category: Matter-WiFi|Platform|Drivers
 quality: production
 metadata:
@@ -38,8 +38,10 @@ include:
   - path: spi_multiplex.h
 - path: third_party/matter_sdk/src/platform/silabs/SiWx/ble
   file_list:
-  - path: ble_config.h
-  - path: sl_si91x_ble_init.h
+    - path: ble_config.h
+      unless: [matter_ble]
+    - path: sl_si91x_ble_init.h
+      unless: [matter_ble]
 - path: third_party/matter_sdk/src/platform/silabs/wifi
   file_list:
   - path: wfx_msgs.h
@@ -47,16 +49,27 @@ include:
   - path: WifiStateProvider.h
 - path: third_party/matter_sdk/src/platform/silabs/wifi/SiWx
   file_list:
-  - path: WifiInterfaceImpl.h
+    - path: WifiInterfaceImpl.h
+- path: third_party/wifi_sdk/components/device/silabs/si91x/wireless/ble/inc
+  file_list:
+    - path: rsi_common_apis.h
 
 source:
+
 - path: third_party/matter_sdk/src/platform/silabs/wifi/WifiInterface.cpp
 - path: third_party/matter_sdk/src/platform/silabs/wifi/SiWx/WifiInterfaceImpl.cpp
 - path: third_party/matter_sdk/src/platform/silabs/wifi/SiWx/ncp/sl_si91x_ncp_utility.c
 - path: third_party/matter_sdk/src/platform/silabs/SiWx/ble/BLEManagerImpl.cpp
+  unless: [matter_ble]
 - path: third_party/matter_sdk/src/platform/silabs/SiWx/ble/sl_si91x_ble_init.cpp
+  unless: [matter_ble]
+- path: third_party/matter_sdk/src/platform/silabs/efr32/BLEManagerImpl.cpp
+  condition: [matter_ble]
 
 define:
+- name: SLI_SI91X_ENABLE_BLE
+  value: "1"
+  unless: [matter_ble]
 - name: SL_MATTER_SIWX_WIFI_ENABLE
 - name: EXP_BOARD
   value: 1

--- a/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
+++ b/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
@@ -67,9 +67,6 @@ source:
   condition: [matter_ble]
 
 define:
-- name: SLI_SI91X_ENABLE_BLE
-  value: "1"
-  unless: [matter_ble]
 - name: SL_MATTER_SIWX_WIFI_ENABLE
 - name: EXP_BOARD
   value: 1

--- a/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
+++ b/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
@@ -38,10 +38,10 @@ include:
   - path: spi_multiplex.h
 - path: third_party/matter_sdk/src/platform/silabs/SiWx/ble
   file_list:
-    - path: ble_config.h
-      unless: [matter_ble]
-    - path: sl_si91x_ble_init.h
-      unless: [matter_ble]
+  - path: ble_config.h
+    unless: [matter_ble]
+  - path: sl_si91x_ble_init.h
+    unless: [matter_ble]
 - path: third_party/matter_sdk/src/platform/silabs/wifi
   file_list:
   - path: wfx_msgs.h
@@ -49,10 +49,11 @@ include:
   - path: WifiStateProvider.h
 - path: third_party/matter_sdk/src/platform/silabs/wifi/SiWx
   file_list:
-    - path: WifiInterfaceImpl.h
+  - path: WifiInterfaceImpl.h
 - path: third_party/wifi_sdk/components/device/silabs/si91x/wireless/ble/inc
   file_list:
-    - path: rsi_common_apis.h
+  - path: rsi_common_apis.h
+    unless: [matter_ble]
 
 source:
 


### PR DESCRIPTION
**Issue Link:** 
Few changes are needed in matter_sdk, which should be merged into CSA and pulled into matter_sdk main, before merging this PR.

**Description of Problem/Feature:**
Allegion Dual Stack architecture required the BLE on EFR32 and disbale 917 BLE.

**Description of Fix/Solution:**
Added new slcp and slcw for lock app example to implement Dual stack architecture. 
Added changes to siw917_ncp to include EFR32 BLE files

**Testing Done:**
Build succesful and BLE commissioning validated

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates build/component configuration for the SiWx917 NCP extension to switch BLE implementations based on `matter_ble`, which could affect other 917 NCP-based projects’ BLE bring-up and link dependencies. Adds new example project/workspace files, so risk is mostly around integration/build configuration rather than runtime logic.
> 
> **Overview**
> Adds a new SLC example (`lock-app-917-ncp-dual-stack.slcp`) and workspace (`.slcw`) to build the Matter lock over WiFi with a bootloader in a *dual-stack* configuration.
> 
> Adjusts the `siwx917_ncp` component to better support BLE + WiFi by conditionally excluding the SiWx917 BLE sources/headers when `matter_ble` is enabled and instead pulling in the EFR32 `BLEManagerImpl`, plus adding the required BLE SDK header include.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f434f71a4d3afe850b49a98654ebb5bf03c6f9d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->