### PR TITLE
MATTER-6156: Adds build for matter AWS flavor for CI check

### DIFF
--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -15,6 +15,12 @@
                 "boards": ["brd4338a"],
                 "arguments": ["--output_suffix  peripherals-icd","--with_app matter_peripherals_917soc,matter_icd_core"]
             }
+        ],
+        "lighting-app": [
+            {
+                "boards": ["brd4338a"],
+                "arguments": ["--output_suffix matter-aws", "--with_app matter_aws"]
+            }
         ]
     },
     "full": {


### PR DESCRIPTION
<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** [MATTER-6156](https://jira.silabs.com/browse/MATTER-6156)

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** The CICD was missing the check for MATTER AWS flavor.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:** The CICD was missing the check for MATTER AWS flavor, since it is SL-ONLY build adding it here for additional coverage.


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Checking with CICD
<img width="1512" height="221" alt="image" src="https://github.com/user-attachments/assets/6a644aa1-1dad-4421-a704-46dc5b5407fd" />

NOTE: To be merged after the following PR has been merged

 - [x] https://github.com/SiliconLabsSoftware/matter_sdk/pull/890