### PR TITLE
NOJIRA: DataModelCallbacks forwarders and AppTask virtual dispatch

### DIFF
--- a/slc/apps/lighting-app/thread/lighting-app.slcp
+++ b/slc/apps/lighting-app/thread/lighting-app.slcp
@@ -99,8 +99,6 @@ source:
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src
-  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/DataModelCallbacks.cpp
-    directory: src
 
 define:
   - name: CHIP_CRYPTO_PLATFORM

--- a/slc/apps/lighting-app/thread/trustzone/lighting-ns.slcp
+++ b/slc/apps/lighting-app/thread/trustzone/lighting-ns.slcp
@@ -103,8 +103,6 @@ source:
     directory: src
   - path: ../../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src
-  - path: ../../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/DataModelCallbacks.cpp
-    directory: src
 
 define:
   - name: CHIP_CRYPTO_PLATFORM

--- a/slc/apps/lighting-app/wifi/lighting-app-siwx.slcp
+++ b/slc/apps/lighting-app/wifi/lighting-app-siwx.slcp
@@ -124,8 +124,6 @@ source:
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src
-  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/DataModelCallbacks.cpp
-    directory: src
 
 define:
   - name: CCP_SI917_BRINGUP

--- a/slc/apps/performance-test-app/thread/performance-test-app.slcp
+++ b/slc/apps/performance-test-app/thread/performance-test-app.slcp
@@ -95,6 +95,8 @@ source:
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/AppTask.cpp
     directory: src
+  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/DataModelCallbacks.cpp
+    directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src
 

--- a/slc/apps/performance-test-app/thread/performance-test-app.slcp
+++ b/slc/apps/performance-test-app/thread/performance-test-app.slcp
@@ -97,8 +97,6 @@ source:
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src
-  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/DataModelCallbacks.cpp
-    directory: src
 
 define:
   - name: SILABS_LOG_OUT_UART

--- a/slc/apps/zigbee-matter-light/thread/zigbee-matter-light.slcp
+++ b/slc/apps/zigbee-matter-light/thread/zigbee-matter-light.slcp
@@ -239,8 +239,6 @@ source:
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src
-  - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/src/DataModelCallbacks.cpp
-    directory: src
 
 include:
   - path: ../../../../third_party/matter_sdk/examples/lighting-app/silabs/include

--- a/slc/component/matter-examples/matter_lighting.slcc
+++ b/slc/component/matter-examples/matter_lighting.slcc
@@ -15,6 +15,7 @@ template_file:
   - path: third_party/matter_sdk/examples/lighting-app/silabs/include/AppTask.h
   - path: third_party/matter_sdk/examples/lighting-app/silabs/include/AppTaskImpl.h
   - path: third_party/matter_sdk/examples/lighting-app/silabs/src/AppTask.cpp
+  - path: third_party/matter_sdk/examples/lighting-app/silabs/src/DataModelCallbacks.cpp
 
 define:
   - name: IS_DEMO_LIGHT


### PR DESCRIPTION
**Issue Link:**

- [MDD-0036 Phase 1b (Confluence)](https://confluence.silabs.com/pages/viewpage.action?pageId=812845423)
- Upstream implementation: [SiliconLabsSoftware/matter_sdk#900](https://github.com/SiliconLabsSoftware/matter_sdk/pull/900) (DataModelCallbacks forwarders and `AppTask` virtual dispatch)

**Description of Problem/Feature:**
MDD-0036 Phase 1b keeps Matter SDK data-model callbacks in a dedicated `DataModelCallbacks.cpp` translation unit while routing behavior through `AppTask` so the CRTP layer (`AppTaskImpl<CommonAppTask>`) can override via `*Impl()` methods. **matter_extension** must stay aligned with that layout: SLC templates and project sources must still include `DataModelCallbacks.cpp` (and any related includes/paths), and the bundled **matter_sdk** revision must contain the matching GN/sources and example changes.

**Description of Fix/Solution:**
- Align **matter_extension** with the Phase 1b pattern: forwarders and default `DmCallback*` logic live with `DataModelCallbacks.cpp`; `AppTask` / `CommonAppTask` / `AppTaskImpl` wiring matches [matter_sdk#900](https://github.com/SiliconLabsSoftware/matter_sdk/pull/900).
- Update **SLC** metadata as needed (e.g. `matter_lighting.slcc` and lighting `.slcp` `source:` / template lists) so generated projects keep **DataModelCallbacks** in the build and match the SDK example.
- Bump or sync **`third_party/matter_sdk`** to the commit/branch that carries the matter_sdk PR (as done on this branch).
- Any **CI / perf / build script** adjustments required for the new file split or submodule revision (e.g. fixes for tests that assumed callbacks lived only in `AppTask.cpp`).



<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
https://github.com/SiliconLabsSoftware/matter_sdk/pull/900