### PR TITLE
MATTER-6170: Update sdk-submodule-bump workflow to select the SiSDK version being updated

### DIFF
--- a/.github/workflows/sdk-submodule-bump.yaml
+++ b/.github/workflows/sdk-submodule-bump.yaml
@@ -3,6 +3,13 @@ name: SDK Submodule Bump
 on:
   workflow_dispatch:
     inputs:
+      sisdk-version:
+        description: 'SiSDK version'
+        required: true
+        type: choice
+        options:
+          - 2025.12
+          - 2026.6
       sisdk-build-number:
         description: 'SDK (sisdk-prerelease and wiseconnect-prerelease) Build Number to bump to (e.g., 1355)'
         required: true
@@ -12,11 +19,39 @@ jobs:
   bump-sdk-submodules:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve SiSDK version and tag
+        id: resolve_inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          SISDK_VERSION="${{ inputs.sisdk-version }}"
+          SISDK_BUILD_NUMBER="${{ inputs.sisdk-build-number }}"
+
+          # Input validation - ensure build number contains only digits
+          if [[ ! "$SISDK_BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "Error: Build number must contain only digits. Received: $SISDK_BUILD_NUMBER"
+            exit 1
+          fi
+
+          SDK_TAG="v${SISDK_VERSION}-build.${SISDK_BUILD_NUMBER}"
+          PR_BRANCH="automation/update_sdk_submodules_${SISDK_VERSION//./_}_${SISDK_BUILD_NUMBER}"
+
+          echo "sisdk_version=$SISDK_VERSION" >> "$GITHUB_OUTPUT"
+          echo "sisdk_build_number=$SISDK_BUILD_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "sdk_tag=$SDK_TAG" >> "$GITHUB_OUTPUT"
+          echo "pr_branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
+
+          echo "Selected SiSDK version: $SISDK_VERSION"
+          echo "Selected build number: $SISDK_BUILD_NUMBER"
+          echo "Resolved SDK tag: $SDK_TAG"
+          echo "Resolved PR branch: $PR_BRANCH"
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           submodules: false
-          ref: release_2.8-1.5
+          ref: ${{ github.ref }}
           persist-credentials: false
       
       - name: Mark repository as safe for Git
@@ -27,32 +62,30 @@ jobs:
       - name: Bump SDK submodules
         shell: bash
         run: |
-          set -euo pipefail
-          
-          SISDK_BUILD_NUMBER="${{ inputs.sisdk-build-number }}"
-          
-          # Input validation - ensure build number contains only digits
-          if [[ ! "$SISDK_BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "Error: Build number must contain only digits. Received: $SISDK_BUILD_NUMBER"
-            exit 1
-          fi
-          
-          echo "Bumping simplicity_sdk to build number: $SISDK_BUILD_NUMBER"
+          set -euo pipefail          
+          SISDK_VERSION="${{ steps.resolve_inputs.outputs.sisdk_version }}"
+          SISDK_BUILD_NUMBER="${{ steps.resolve_inputs.outputs.sisdk_build_number }}"
+          SDK_TAG="${{ steps.resolve_inputs.outputs.sdk_tag }}"
+
+          echo "Bumping simplicity_sdk and wifi_sdk"
+          echo "SiSDK version: $SISDK_VERSION"
+          echo "Build number: $SISDK_BUILD_NUMBER"
+          echo "Tag: $SDK_TAG"
 
           git submodule update --init third_party/simplicity_sdk
           git submodule update --init third_party/wifi_sdk
           cd third_party/simplicity_sdk
           git fetch origin
-          git checkout v2025.12-build.$SISDK_BUILD_NUMBER
+          git checkout "$SDK_TAG"
+
           cd ../wifi_sdk
           git fetch origin
-          git checkout v2025.12-build.$SISDK_BUILD_NUMBER
+          git checkout "$SDK_TAG"
           cd ../..
 
           echo "Updating .gitmodules tags..."
           # Update the tags in .gitmodules
-          sed -i "s|^\(\s*tag = \)v2025\.12-build\.[0-9]*$|\1v2025.12-build.$SISDK_BUILD_NUMBER|g" .gitmodules
-          
+          sed -i "s|^\(\s*tag = \)\(v2025\.12\|v2026\.6\)-build\.[0-9]*$|\1\2-build.$SISDK_BUILD_NUMBER|g" .gitmodules
           # Display the updated .gitmodules content
           echo "Updated .gitmodules:"
           cat .gitmodules
@@ -73,10 +106,14 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
-            branch: automation/update_sdk_submodules
-            base: release_2.8-1.5
-            title: "Update SDK submodules on release_2.8-1.5"
-            body: |
-                This PR updates the simplicity_sdk and wifi_sdk submodules to the ${{ inputs.sisdk-build-number }} on the release_2.8-1.5 branch.
+          branch: ${{ steps.resolve_inputs.outputs.pr_branch }}
+          base: ${{ github.ref_name }}
+          title: "Update SDK submodules to ${{ steps.resolve_inputs.outputs.sdk_tag }} on ${{ github.ref_name }}"
+          body: |
+            This PR updates the simplicity_sdk and wifi_sdk submodules to `${{ steps.resolve_inputs.outputs.sdk_tag }}` on the `${{ github.ref_name }}` branch.
+
+            - SiSDK version: `${{ steps.resolve_inputs.outputs.sisdk_version }}`
+            - Build number: `${{ steps.resolve_inputs.outputs.sisdk_build_number }}`
+            - Resolved tag: `${{ steps.resolve_inputs.outputs.sdk_tag }}`
 
             token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/sdk-submodule-bump.yaml
+++ b/.github/workflows/sdk-submodule-bump.yaml
@@ -85,7 +85,7 @@ jobs:
 
           echo "Updating .gitmodules tags..."
           # Update the tags in .gitmodules
-          sed -i "s|^\(\s*tag = \)\(v2025\.12\|v2026\.6\)-build\.[0-9]*$|\1\2-build.$SISDK_BUILD_NUMBER|g" .gitmodules
+          sed -i -E "s#^([[:space:]]*tag = )(v2025\.12|v2026\.6)-build\.[0-9]*\$#\1\2-build.${SISDK_BUILD_NUMBER}#g" .gitmodules
           # Display the updated .gitmodules content
           echo "Updated .gitmodules:"
           cat .gitmodules

--- a/.github/workflows/sdk-submodule-bump.yaml
+++ b/.github/workflows/sdk-submodule-bump.yaml
@@ -86,7 +86,7 @@ jobs:
 
           echo "Updating .gitmodules tags..."
           # Update the tags in .gitmodules
-          sed -i -E "s#^([[:space:]]*tag = )(v2025\.12|v2026\.6)-build\.[0-9]*\$#\1\2-build.${SISDK_BUILD_NUMBER}#g" .gitmodules
+          sed -i -E "s#^([[:space:]]*tag = )(v2025\.12|v2026\.6)-build\.[0-9]*\$#\1${SDK_TAG}#g" .gitmodules
           # Display the updated .gitmodules content
           echo "Updated .gitmodules:"
           cat .gitmodules

--- a/.github/workflows/sdk-submodule-bump.yaml
+++ b/.github/workflows/sdk-submodule-bump.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       sisdk-version:
-        description: 'SiSDK version'
+        description: 'SiSDK version (2025.12 → release_2.8, 2026.6 → integration/sdk-26q2)'
         required: true
         type: choice
         default: '2026.6'
@@ -35,6 +35,15 @@ jobs:
             exit 1
           fi
 
+          case "$SISDK_VERSION" in
+            "2025.12")
+              TARGET_BRANCH="release_2.8"
+              ;;
+            "2026.6")
+              TARGET_BRANCH="integration/sdk-26q2"
+              ;;
+          esac
+
           SDK_TAG="v${SISDK_VERSION}-build.${SISDK_BUILD_NUMBER}"
           PR_BRANCH="automation/update_sdk_submodules_${SISDK_VERSION//./_}_${SISDK_BUILD_NUMBER}"
 
@@ -42,9 +51,11 @@ jobs:
           echo "sisdk_build_number=$SISDK_BUILD_NUMBER" >> "$GITHUB_OUTPUT"
           echo "sdk_tag=$SDK_TAG" >> "$GITHUB_OUTPUT"
           echo "pr_branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
+          echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
 
           echo "Selected SiSDK version: $SISDK_VERSION"
           echo "Selected build number: $SISDK_BUILD_NUMBER"
+          echo "Resolved target branch: $TARGET_BRANCH"
           echo "Resolved SDK tag: $SDK_TAG"
           echo "Resolved PR branch: $PR_BRANCH"
 
@@ -52,7 +63,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: false
-          ref: ${{ github.ref }}
+          ref: ${{ steps.resolve_inputs.outputs.target_branch }}
           persist-credentials: false
       
       - name: Mark repository as safe for Git
@@ -108,13 +119,13 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           branch: ${{ steps.resolve_inputs.outputs.pr_branch }}
-          base: ${{ github.ref_name }}
-          title: "Update SDK submodules to ${{ steps.resolve_inputs.outputs.sdk_tag }} on ${{ github.ref_name }}"
+          base: ${{ steps.resolve_inputs.outputs.target_branch }}
+          title: "Update SDK submodules to ${{ steps.resolve_inputs.outputs.sdk_tag }} on ${{ steps.resolve_inputs.outputs.target_branch }}"
           body: |
-            This PR updates the simplicity_sdk and wifi_sdk submodules to `${{ steps.resolve_inputs.outputs.sdk_tag }}` on the `${{ github.ref_name }}` branch.
+            This PR updates the simplicity_sdk and wifi_sdk submodules to `${{ steps.resolve_inputs.outputs.sdk_tag }}` on the `${{ steps.resolve_inputs.outputs.target_branch }}` branch.
 
             - SiSDK version: `${{ steps.resolve_inputs.outputs.sisdk_version }}`
             - Build number: `${{ steps.resolve_inputs.outputs.sisdk_build_number }}`
             - Resolved tag: `${{ steps.resolve_inputs.outputs.sdk_tag }}`
 
-            token: ${{ steps.generate_token.outputs.token }}
+          token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/sdk-submodule-bump.yaml
+++ b/.github/workflows/sdk-submodule-bump.yaml
@@ -7,6 +7,7 @@ on:
         description: 'SiSDK version'
         required: true
         type: choice
+        default: '2026.6'
         options:
           - 2025.12
           - 2026.6


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** MATTER-6170

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**  Update matter_extension workflow to explicitly select the SiSDK version it is bumping (ex: 2026.6) and the target branch.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:** 
- Dispatch inputs – Adds a required sisdk-version choice (2025.12 / 2026.6) and a step that validates the build number, forms the SDK tag (v<version>-build.<n>), and names the automation PR branch from those inputs.
- Branch targeting – Checks out and opens the PR against the branch you pick when running the workflow (github.ref / github.ref_name) instead of hardcoding release_2.8-1.5.
- Submodule bump – Checks out that tag on simplicity_sdk and wifi_sdk, and updates .gitmodules for both v2025.12-build.* and v2026.6-build.* tag lines (replacing the old single-version sed).


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
- Tested by running the CI in my forked repo. [CI Link](https://github.com/silabs-ArghyaD/matter_extension/actions/runs/23909386510)
- The test CI failed due to GH Tokens (which is expected), but we can see from the logs that the [SDK tag](https://github.com/silabs-ArghyaD/matter_extension/actions/runs/23909386510/job/69727007906#step:5:38) is set properly and the [.gitmodule](https://github.com/silabs-ArghyaD/matter_extension/actions/runs/23909386510/job/69727007906#step:5:49) has also updated properly.
<img width="358" height="411" alt="image" src="https://github.com/user-attachments/assets/7ccb3f4d-f16c-4966-9783-41ed8d379dca" />
