### PR TITLE
NOJIRA: Removed matter_sdk commit summary from Slack notification

### DIFF
--- a/jenkins_integration/commit_change_summary.sh
+++ b/jenkins_integration/commit_change_summary.sh
@@ -8,7 +8,7 @@ PREV="${PREV_BASELINE:-}"
 HEADS=$(git rev-parse --short HEAD 2>/dev/null || echo "?")
 PREV_FULL=
 
-if [ -z "$PREV"] || ! PREV_FULL=$(git rev-parse -q --verify "${PREV}^{commit}" 2>/dev/null); then # baseline SHA not in repo (e.g. force-push, shallow clone)
+if [ -z "$PREV" ] || ! PREV_FULL=$(git rev-parse -q --verify "${PREV}^{commit}" 2>/dev/null); then # baseline SHA not in repo (e.g. force-push, shallow clone)
   MAIN=$(git log -n "$MAX" --oneline HEAD 2>/dev/null)
   printf "*matter_extension:* no previous Jenkins baseline; last %s commits:\n%s\n\n" "$MAX" "$MAIN"
 else # valid baseline commit

--- a/jenkins_integration/commit_change_summary.sh
+++ b/jenkins_integration/commit_change_summary.sh
@@ -30,11 +30,9 @@ fi
 
 if [ -n "$PREV_SM" ] && [ -n "$CURR_SM" ] && [ "$PREV_SM" != "$CURR_SM" ]; then # submodule pointer moved
   git -C third_party/matter_sdk fetch --quiet origin "$PREV_SM" "$CURR_SM" 2>/dev/null || true
-  SM_LOG=$(git -C third_party/matter_sdk log --oneline "${PREV_SM}..${CURR_SM}" 2>/dev/null | head -n "$MAX")
   PS=$(echo "$PREV_SM" | cut -c1-7)
   CS=$(echo "$CURR_SM" | cut -c1-7)
-  [ -z "$SM_LOG" ] && SM_LOG="(unable to list commits; pointer ${PS} -> ${CS})" # fetch/history missing
-  printf "*matter_sdk (%s..%s):*\n%s\n" "$PS" "$CS" "$SM_LOG"
+  printf "*matter_sdk (%s..%s)*\n" "$PS" "$CS"
 elif [ -z "$PREV_FULL" ] && [ -n "$CURR_SM" ]; then # no resolved baseline; only show current pointer
   CS=$(echo "$CURR_SM" | cut -c1-7)
   printf "*matter_sdk:* no previous Jenkins baseline; pointer %s\n" "$CS"


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** N/A

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** Need to update the Jenkins build notification on Slack as it's getting truncated due to 40k characters limit for posting messages on Slack. More details [here](https://docs.slack.dev/changelog/2018-truncating-really-long-messages/#:~:text=Know%20now%20that%20messages%20with%20tremendously%20long%20text%20bodies%20will%20be%20truncated%20to%20(eventually)%20up%20to%2040%2C000%20characters.).

A matter_sdk change is accompanied by matter_extension change. So we should be fine if matter_sdk changes are removed.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:** 
- Removed the matter_sdk commit summary list.
- Kept the commit hash like `matter_sdk (PREV..CURR)`
- Fixed a minor syntax error in the script.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:** 
As the changes are done in the bash script, so locally tested it using another script. Here's s sample output:
```console
> ./test_commit_change_summary.sh HEAD~5
*matter_extension (bc65be73a..64d77ffe1):*
64d77ffe1 NOJIRA: Removed matter_sdk commit summary from Slack notification
8fe299e10 [main] Update matter_sdk submodule to 47761a3cfb (#587)
80a22f366 Bump actions/setup-python from 5 to 6 (#578)
3ef970347 Bump actions/checkout from 5 to 6 (#579)
e0ae47d6e MATTER-6161: Add build changes to Slack message in matter-release-build-notifications (#586)

*matter_sdk (ead2292..47761a3)*
```