### PR TITLE
MATTER-5803: Add LTO build configurations SiWx ICD applications

### DIFF
--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -40,6 +40,12 @@
                 "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
             }
         ],
+        "lock_app": [
+            {
+                "boards": ["brd4338a"],
+                "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
+            }
+        ],
         "platform_template": [
             {
                 "boards": ["brd4338a", "brd4343a", "brd4342a"],
@@ -108,6 +114,11 @@
                               "--with_app matter_platform_low_power",
                               "--without_app matter_shell,matter_qr_code,matter_lcd,matter_lcd_917SOC,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart",
                               "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
+            },
+            {
+                "boards": ["brd4338a", "brd4342a", "brd4343a"],
+                "arguments": ["--output_suffix lto",
+                              "--with_app toolchain_gcc_lto"]
             },
             {
                 "boards": ["brd4338a"],

--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -116,11 +116,6 @@
                               "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             },
             {
-                "boards": ["brd4338a", "brd4342a", "brd4343a"],
-                "arguments": ["--output_suffix lto",
-                              "--with_app toolchain_gcc_lto"]
-            },
-            {
                 "boards": ["brd4338a"],
                 "arguments": ["--output_suffix low-power-sync-false",
                               "--with_app matter_platform_low_power",


### PR DESCRIPTION
<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** MATTER-5803 MATTER-5936

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** LTO build were disabled due to issues with UART drivers in the sleepy applications.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:** A fix was given by platform team to fix the issue with UART.


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:** CICD