### PR TITLE
NOJIRA: Disable release builds

### DIFF
--- a/.github/workflows/trigger-dev-apps.yaml
+++ b/.github/workflows/trigger-dev-apps.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch: [release_2.9-1.6]
+        branch: [release_2.9-1.6] # TODO: re-enable this workflow in UI after release_2.9-1.6 is created
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/trigger-dev-apps.yaml
+++ b/.github/workflows/trigger-dev-apps.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        branch: [release_2.8-1.5]
+        branch: [release_2.9-1.6]
 
     steps:
       - name: Checkout repository

--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -4,10 +4,7 @@
 def pipelineProperties = []
 
 // Configure pollSCM triggers
-if(env.BRANCH_NAME == 'release_2.8-1.5'){
-    // Trigger daily at 10:05pm EDT (2 hrs after github trigger)
-    pipelineProperties << pipelineTriggers([pollSCM('5 2 * * *')])
-} else if(env.BRANCH_NAME == 'main'){
+if(env.BRANCH_NAME == 'main'){
     // Trigger Thursday at 10:05pm EDT (2 hrs after github trigger)
     pipelineProperties << pipelineTriggers([pollSCM('5 2 * * 5')])
 } 


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Need to disable builds on release branch

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Remove release_2.8 build trigger from trigger-dev-apps and Jenkins polling.
In trigger-dev-apps, matrix cannot be empty so filled it with future release_2.9-1.6 branch and disabled in UI for now. Need to re-enable when release_2.9-1.6 builds needed. 
https://github.com/SiliconLabsSoftware/matter_extension/actions/workflows/trigger-dev-apps.yaml

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reduces automation by removing release-branch scheduled triggers in both GitHub Actions and Jenkins, which could lead to missed release builds if re-enablement is forgotten or branch names change.
> 
> **Overview**
> Disables scheduled builds for the existing release branch by removing the `release_2.8-1.5` trigger paths.
> 
> The GitHub Actions `trigger-dev-apps` workflow now targets a placeholder future branch (`release_2.9-1.6`) to keep the matrix non-empty, and the Jenkins `pollSCM` trigger is restricted to `main` only (no release-branch polling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18adf0070ef6472b9556e44a2b334ac47d1edf76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->