### PR TITLE
NOJIRA: Disable release builds

### DIFF
--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -1,16 +1,6 @@
 #!groovy
 @Library('gsdk-shared-lib@master')
 
-def pipelineProperties = []
-
-// Configure pollSCM triggers
-if(env.BRANCH_NAME == 'main'){
-    // Trigger Thursday at 10:05pm EDT (2 hrs after github trigger)
-    pipelineProperties << pipelineTriggers([pollSCM('5 2 * * 5')])
-} 
-
-properties(pipelineProperties)
-
 def commit_sha = ""
 def run_number = ""
 def workflow_id = ""

--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -4,10 +4,7 @@
 def pipelineProperties = []
 
 // Configure pollSCM triggers
-if(env.BRANCH_NAME == 'release_2.8-1.5'){
-    // Trigger daily at 10:05pm EDT (2 hrs after github trigger)
-    pipelineProperties << pipelineTriggers([pollSCM('5 2 * * *')])
-} else if(env.BRANCH_NAME == 'main'){
+if(env.BRANCH_NAME == 'main'){
     // Trigger Thursday at 10:05pm EDT (2 hrs after github trigger)
     pipelineProperties << pipelineTriggers([pollSCM('5 2 * * 5')])
 } 


### PR DESCRIPTION
**Issue Link:**
NOJIRA

**Description of Problem/Feature:**
Need to disable builds on release branch

**Description of Fix/Solution:**
Remove release_2.8 build trigger from Jenkins polling.
main branch PR disables the github trigger: https://github.com/SiliconLabsSoftware/matter_extension/pull/608

**Testing Done:**
CI


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Disables scheduled Jenkins polling on `main` and `release_2.8-1.5`, which can stop automatic builds if no other trigger is configured.
> 
> **Overview**
> Removes the Jenkins `properties(...)` configuration that added `pollSCM` triggers for `release_2.8-1.5` (daily) and `main` (weekly), effectively disabling Jenkins-scheduled builds from this `Jenkinsfile`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f4b10a5b14abaf380026cd829ac83e63ed778cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->