### PR TITLE
Switch OpenThread ECDSA implementation to non-deterministic

### DIFF
--- a/slc/component/matter-thread/matter_ot_mbedtls_override.slcc
+++ b/slc/component/matter-thread/matter_ot_mbedtls_override.slcc
@@ -10,6 +10,7 @@ metadata:
 provides:
   - name: ot_mbedtls
   - name: matter_ot_mbedtls_override
-
+requires:
+  - name: ot_crypto_ecdsa_nondeterministic
 ui_hints:
   visibility: never


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
MATTER-5921 
OPENTHREAD-6310
Reduces code size by specifying which ECDSA algo we want for OT
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**

Most of the stacks, including Matter and BLE uses the non-determinitics implementation of ECDSA, OpenThread used to force the deterministic one resulting in BOTH implementation being present on the DUT causing a code size bloat.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
With OPENTHREAD-6310 being fixed we can know specified which implementation we want. The non deterministic one was choosen because it's the default one on CSA and all other components used it

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
MG24 device was successfully commissioned and was able to receive commands.