### PR TITLE
Add properties field to Jenkinsfile

### DIFF
--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -1,6 +1,16 @@
 #!groovy
 @Library('gsdk-shared-lib@master')
 
+def pipelineProperties = []
+
+// Configure pollSCM triggers
+if(env.BRANCH_NAME == 'main'){
+    // Trigger Thursday at 10:05pm EDT (2 hrs after github trigger)
+    pipelineProperties << pipelineTriggers([pollSCM('5 2 * * 5')])
+} 
+
+properties(pipelineProperties)
+
 def commit_sha = ""
 def run_number = ""
 def workflow_id = ""


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Removed polling on release branch, but is still triggering daily. This is because PR removed properties field, so there was no new properties set to overwrite the existing polling configuration. 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Reintroduce properties field with main branch polling config (no-op on this branch, unsure how assigning empty property field would behave)

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Jenkins job properties to explicitly reset/define SCM polling, which can affect when pipelines run and could unintentionally add or remove scheduled executions.
> 
> **Overview**
> Reintroduces a `properties(pipelineProperties)` block in the `Jenkinsfile` to explicitly set Jenkins job properties each run.
> 
> Adds a `main`-only `pollSCM` schedule (`5 2 * * 5`) so scheduled polling is configured for `main` and effectively cleared for other branches by applying an empty properties list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 291005e5020fd24cdc30f57db086f17c314965ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->