### PR TITLE
Pick up release_2.9-1.6 in github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,4 +21,4 @@ updates:
       time: "08:00"
     allow:
       - dependency-name: "third_party/matter_support"
-    target-branch: "release_2.8-1.5"
+    target-branch: "release_2.9-1.6"

--- a/.github/workflows/sdk-submodule-bump.yaml
+++ b/.github/workflows/sdk-submodule-bump.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       sisdk-version:
-        description: 'SiSDK version (2025.12 → release_2.8, 2026.6 → integration/sdk-26q2)'
+        description: 'SiSDK version (2025.12 → release_2.8, 2026.6 → release_2.9-1.6)'
         required: true
         type: choice
         default: '2026.6'
@@ -40,7 +40,7 @@ jobs:
               TARGET_BRANCH="release_2.8"
               ;;
             "2026.6")
-              TARGET_BRANCH="integration/sdk-26q2"
+              TARGET_BRANCH="release_2.9-1.6"
               ;;
           esac
 

--- a/.github/workflows/update-matter_sdk.yml
+++ b/.github/workflows/update-matter_sdk.yml
@@ -17,7 +17,7 @@ jobs:
       - id: branches
         run: |
           if [ "$EVENT_NAME" == "schedule" ]; then
-            echo 'value=["main","release_2.8-1.5"]' >> $GITHUB_OUTPUT
+            echo 'value=["main","release_2.9-1.6"]' >> $GITHUB_OUTPUT
           else
             echo "value=[\"$REF_NAME\"]" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
need to pick up new release branch in github actions workflows

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
update all refs of release_2.8-1.5 and integration branch to release_2.9-1.6 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates Dependabot and GitHub Actions branch targets/labels; main risk is automation running against the wrong release branch if the mapping is incorrect.
> 
> **Overview**
> Updates automation to track the new `release_2.9-1.6` branch instead of `release_2.8-1.5`/`integration/sdk-26q2`.
> 
> Dependabot submodule updates and the scheduled `update-matter_sdk` workflow now target `main` and `release_2.9-1.6`, and `sdk-submodule-bump` maps SiSDK `2026.6` runs to `release_2.9-1.6` (including the dispatch input description).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6516cc20378c885084b3d345cc0dd59646cc3025. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->