### PR TITLE
Fix CRTP README

### DIFF
--- a/slc/apps/lighting-app/thread/README.md
+++ b/slc/apps/lighting-app/thread/README.md
@@ -109,9 +109,19 @@ To implement custom app behavior you can override any Silicon Labs implemented A
 3. Implement the method in `CommonAppTask.cpp`.
 4. Build the project. Each overridable API is resolved as follows: **if you implemented that `*Impl()` in CommonAppTask, your implementation is used, otherwise the Silicon Labs default implementation is used.** You only implement what you need, everything else falls back to the default automatically.
 
-### Required Override
+### DataModelCallbacks and CommonAppTask
 
-- **`CHIP_ERROR AppInitImpl()`** — Required to override default AppTask implementation. 
+`DataModelCallbacks.cpp` implements existing
+data model methods for this app and forwards attribute updates into `AppTask`
+through CRTP.
+
+- **Methods that already exist in `DataModelCallbacks.cpp`** — Customize them by
+  overriding the matching `*Impl()` method in `CommonAppTask`. Do not rely on
+  editing `DataModelCallbacks.cpp` directly.
+
+- **New custom data model methods** — Add method in `CommonAppTask` directly. Do
+  not add new application logic in `DataModelCallbacks.cpp`, edits to this file
+  will not survive project upgrades
 
 ### Sample Implementation
 


### PR DESCRIPTION
remove outdated required override section, add datamodelcallbacks section

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that clarifies where to place override logic; no runtime behavior is modified.
> 
> **Overview**
> Updates the lighting-app Thread README to remove the outdated *Required Override* guidance and replace it with a clearer section explaining how `DataModelCallbacks.cpp` forwards into `AppTask` via CRTP.
> 
> It now instructs developers to customize existing data model callbacks by overriding matching `*Impl()` methods in `CommonAppTask`, and to add new app logic in `CommonAppTask` rather than editing `DataModelCallbacks.cpp` (since that file may be regenerated on upgrades).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 640c572bade1378a5360f025b01fd8a7ec148a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->