### PR TITLE
Upgrade GCC version on SLT and changing the component name to reflect the LTO changes

### DIFF
--- a/.github/actions/install-tools/action.yaml
+++ b/.github/actions/install-tools/action.yaml
@@ -80,7 +80,7 @@ runs:
     - name: install gcc-arm-none-eabi
       shell: bash
       run: |
-        conan remote add silabs-conan-prerelease https://conan-prerelease.silabs.net/ -f
+        conan remote add silabs-conan-prerelease https://conan-prerelease.silabs.net
         slt install gcc-arm-none-eabi/14.2.rel1
         ARM_GCC_DIR=$(slt where gcc-arm-none-eabi)
         echo "ARM_GCC_DIR=$ARM_GCC_DIR" >> $GITHUB_ENV

--- a/.github/actions/install-tools/action.yaml
+++ b/.github/actions/install-tools/action.yaml
@@ -28,6 +28,7 @@ runs:
         echo "SLT_PATH=${{ steps.setup-action.outputs.slt-path }}" >> $GITHUB_ENV
         echo "/tmp/zap-linux-x64" >> $GITHUB_PATH
         echo "${{ steps.setup-action.outputs.slt-path }}" >> $GITHUB_PATH
+        echo "${{ steps.setup-action.outputs.conan-path }}" >> $GITHUB_PATH
     
     - name: Update SLT
       shell: bash
@@ -79,7 +80,8 @@ runs:
     - name: install gcc-arm-none-eabi
       shell: bash
       run: |
-        slt install gcc-arm-none-eabi/12.2.rel1
+        conan remote add silabs-conan-prerelease https://conan-prerelease.silabs.net/ -f
+        slt install gcc-arm-none-eabi/14.2.rel1
         ARM_GCC_DIR=$(slt where gcc-arm-none-eabi)
         echo "ARM_GCC_DIR=$ARM_GCC_DIR" >> $GITHUB_ENV
         echo "$ARM_GCC_DIR/bin" >> $GITHUB_PATH

--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -31,7 +31,7 @@
         "lighting-app": [
             {
                 "boards": ["brd4338a"],
-                "arguments": ["--output_suffix lto", "--with_app wiseconnect_toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
+                "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
             }
         ],
         "platform-template": [
@@ -71,11 +71,11 @@
             {
                 "boards": ["brd4338a", "brd4342a", "brd4343a"],
                 "arguments": ["--output_suffix lto",
-                              "--with_app wiseconnect_toolchain_gcc_lto"]
+                              "--with_app toolchain_gcc_lto"]
             },
             {
                 "boards": ["brd4338a", "brd4342a"],
-                "arguments": ["--output_suffix lto-ota-2", "--with_app wiseconnect_toolchain_gcc_lto",
+                "arguments": ["--output_suffix lto-ota-2", "--with_app toolchain_gcc_lto",
                               "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ],
@@ -88,7 +88,7 @@
             {
                 "boards": ["brd4338a", "brd4342a", "brd4343a"],
                 "arguments": ["--output_suffix lto",
-                              "--with_app wiseconnect_toolchain_gcc_lto"]
+                              "--with_app toolchain_gcc_lto"]
             },
             {
                 "boards": ["brd4338a"],

--- a/slc/build.sh
+++ b/slc/build.sh
@@ -289,9 +289,9 @@ if ! [ -d "$ARM_GCC_DIR/bin" ]; then
 	exit 1
 fi
 
-if ! [ -x "$(command -v arm-none-eabi-gcc-12.2.1)" ]; then
+if ! [ -x "$(command -v arm-none-eabi-gcc-14.2.1)" ]; then
 	echo "WARNING: might be an incompatible toolchain."
-	echo "Please install gcc-arm-none-eabi-12.2.Rel1 for your host."
+	echo "Please install gcc-arm-none-eabi-14.2.Rel1 for your host."
 fi
 
 echo "Building $SILABS_APP for $SILABS_BOARD in $OUTPUT_DIR"


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
https://jira.silabs.com/browse/MATTER-6024
https://jira.silabs.com/browse/MATTER-5803

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Upgrade of the gcc-arm-none-eabi from 12.2 to 14.2 release.
Component deprecation, and corresponding name change in the WiseConnect 4.1.0

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
 Adds prerelease remote for slt and install gcc-arm-none-eabi 14.2 release.
 Changing the component name to reflect LTO build component.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Manually, locally and CICD testing.