### PR TITLE
Add pure code driven support in SLC

### DIFF
--- a/slc/apps/air-quality-sensor-app/thread/air-quality-sensor-app.slcp
+++ b/slc/apps/air-quality-sensor-app/thread/air-quality-sensor-app.slcp
@@ -39,6 +39,7 @@ component:
   - id: matter_ethernet_network_diagnostics
   - id: matter_wifi_network_diagnostics
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/air-quality-sensor-app/thread/air-quality-sensor-app.slcp
+++ b/slc/apps/air-quality-sensor-app/thread/air-quality-sensor-app.slcp
@@ -39,7 +39,7 @@ component:
   - id: matter_ethernet_network_diagnostics
   - id: matter_wifi_network_diagnostics
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/air-quality-sensor-app/wifi/air-quality-sensor-app-siwx.slcp
+++ b/slc/apps/air-quality-sensor-app/wifi/air-quality-sensor-app-siwx.slcp
@@ -31,6 +31,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/air-quality-sensor-app/wifi/air-quality-sensor-app-siwx.slcp
+++ b/slc/apps/air-quality-sensor-app/wifi/air-quality-sensor-app-siwx.slcp
@@ -31,7 +31,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/closure-app/thread/closure-app.slcp
+++ b/slc/apps/closure-app/thread/closure-app.slcp
@@ -31,6 +31,7 @@ component:
   - id: matter_closure_control
   - id: matter_closure_dimension
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/closure-app/thread/closure-app.slcp
+++ b/slc/apps/closure-app/thread/closure-app.slcp
@@ -31,7 +31,7 @@ component:
   - id: matter_closure_control
   - id: matter_closure_dimension
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/closure-app/wifi/closure-app-siwx.slcp
+++ b/slc/apps/closure-app/wifi/closure-app-siwx.slcp
@@ -22,7 +22,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/closure-app/wifi/closure-app-siwx.slcp
+++ b/slc/apps/closure-app/wifi/closure-app-siwx.slcp
@@ -22,6 +22,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/dishwasher-app/thread/dishwasher-app.slcp
+++ b/slc/apps/dishwasher-app/thread/dishwasher-app.slcp
@@ -34,6 +34,7 @@ component:
 
   - id: matter_dishwasher
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/dishwasher-app/thread/dishwasher-app.slcp
+++ b/slc/apps/dishwasher-app/thread/dishwasher-app.slcp
@@ -34,7 +34,7 @@ component:
 
   - id: matter_dishwasher
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/dishwasher-app/wifi/dishwasher-app-siwx.slcp
+++ b/slc/apps/dishwasher-app/wifi/dishwasher-app-siwx.slcp
@@ -29,7 +29,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/dishwasher-app/wifi/dishwasher-app-siwx.slcp
+++ b/slc/apps/dishwasher-app/wifi/dishwasher-app-siwx.slcp
@@ -29,6 +29,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/evse-app/thread/evse-app.slcp
+++ b/slc/apps/evse-app/thread/evse-app.slcp
@@ -65,7 +65,7 @@ component:
     from: matter
   - id: matter_mode_base
     from: matter
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
     from: matter
   - id: matter_administrator_commissioning

--- a/slc/apps/evse-app/thread/evse-app.slcp
+++ b/slc/apps/evse-app/thread/evse-app.slcp
@@ -65,6 +65,7 @@ component:
     from: matter
   - id: matter_mode_base
     from: matter
+  - id: matter_zap_driven_dm
   - id: matter_access_control
     from: matter
   - id: matter_administrator_commissioning

--- a/slc/apps/evse-app/wifi/evse-app-siwx.slcp
+++ b/slc/apps/evse-app/wifi/evse-app-siwx.slcp
@@ -36,7 +36,7 @@ component:
   - id: matter_provision_flash
     from: matter
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
     from: matter
   - id: matter_administrator_commissioning

--- a/slc/apps/evse-app/wifi/evse-app-siwx.slcp
+++ b/slc/apps/evse-app/wifi/evse-app-siwx.slcp
@@ -36,6 +36,7 @@ component:
   - id: matter_provision_flash
     from: matter
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
     from: matter
   - id: matter_administrator_commissioning

--- a/slc/apps/fan-control-app/thread/fan-control-app.slcp
+++ b/slc/apps/fan-control-app/thread/fan-control-app.slcp
@@ -34,7 +34,7 @@ component:
 
   - id: matter_fan_control
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/fan-control-app/thread/fan-control-app.slcp
+++ b/slc/apps/fan-control-app/thread/fan-control-app.slcp
@@ -34,6 +34,7 @@ component:
 
   - id: matter_fan_control
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/fan-control-app/wifi/fan-control-app-917-ncp.slcp
+++ b/slc/apps/fan-control-app/wifi/fan-control-app-917-ncp.slcp
@@ -39,6 +39,7 @@ component:
   - id: psa_crypto_tls12_prf
     condition: [matter_aws]
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/fan-control-app/wifi/fan-control-app-917-ncp.slcp
+++ b/slc/apps/fan-control-app/wifi/fan-control-app-917-ncp.slcp
@@ -39,7 +39,7 @@ component:
   - id: psa_crypto_tls12_prf
     condition: [matter_aws]
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/fan-control-app/wifi/fan-control-app-siwx.slcp
+++ b/slc/apps/fan-control-app/wifi/fan-control-app-siwx.slcp
@@ -26,7 +26,7 @@ component:
   - id: matter_wifi
   - id: app_common
   - id: matter_provision_flash
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/fan-control-app/wifi/fan-control-app-siwx.slcp
+++ b/slc/apps/fan-control-app/wifi/fan-control-app-siwx.slcp
@@ -26,6 +26,7 @@ component:
   - id: matter_wifi
   - id: app_common
   - id: matter_provision_flash
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/light-switch-app/thread/light-switch-app.slcp
+++ b/slc/apps/light-switch-app/thread/light-switch-app.slcp
@@ -35,6 +35,7 @@ component:
 
   - id: matter_light_switch
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/light-switch-app/thread/light-switch-app.slcp
+++ b/slc/apps/light-switch-app/thread/light-switch-app.slcp
@@ -35,7 +35,7 @@ component:
 
   - id: matter_light_switch
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/light-switch-app/wifi/light-switch-app-siwx.slcp
+++ b/slc/apps/light-switch-app/wifi/light-switch-app-siwx.slcp
@@ -29,7 +29,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/light-switch-app/wifi/light-switch-app-siwx.slcp
+++ b/slc/apps/light-switch-app/wifi/light-switch-app-siwx.slcp
@@ -29,6 +29,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lighting-app/thread/lighting-app.slcp
+++ b/slc/apps/lighting-app/thread/lighting-app.slcp
@@ -34,7 +34,7 @@ component:
 
   - id: matter_lighting
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lighting-app/thread/lighting-app.slcp
+++ b/slc/apps/lighting-app/thread/lighting-app.slcp
@@ -34,6 +34,7 @@ component:
 
   - id: matter_lighting
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lighting-app/thread/trustzone/lighting-ns.slcp
+++ b/slc/apps/lighting-app/thread/trustzone/lighting-ns.slcp
@@ -34,7 +34,7 @@ component:
 
   - id: matter_lighting
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lighting-app/thread/trustzone/lighting-ns.slcp
+++ b/slc/apps/lighting-app/thread/trustzone/lighting-ns.slcp
@@ -34,6 +34,7 @@ component:
 
   - id: matter_lighting
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lighting-app/wifi/lighting-app-siwx.slcp
+++ b/slc/apps/lighting-app/wifi/lighting-app-siwx.slcp
@@ -27,7 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lighting-app/wifi/lighting-app-siwx.slcp
+++ b/slc/apps/lighting-app/wifi/lighting-app-siwx.slcp
@@ -27,6 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lock-app/thread/lock-app.slcp
+++ b/slc/apps/lock-app/thread/lock-app.slcp
@@ -35,7 +35,7 @@ component:
   - id: app_common
   - id: matter_provision_default
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lock-app/thread/lock-app.slcp
+++ b/slc/apps/lock-app/thread/lock-app.slcp
@@ -35,6 +35,7 @@ component:
   - id: app_common
   - id: matter_provision_default
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lock-app/wifi/lock-app-917-ncp.slcp
+++ b/slc/apps/lock-app/wifi/lock-app-917-ncp.slcp
@@ -39,6 +39,7 @@ component:
   - id: psa_crypto_tls12_prf
     condition: [matter_aws]
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lock-app/wifi/lock-app-917-ncp.slcp
+++ b/slc/apps/lock-app/wifi/lock-app-917-ncp.slcp
@@ -39,7 +39,7 @@ component:
   - id: psa_crypto_tls12_prf
     condition: [matter_aws]
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lock-app/wifi/lock-app-siwx.slcp
+++ b/slc/apps/lock-app/wifi/lock-app-siwx.slcp
@@ -27,7 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/lock-app/wifi/lock-app-siwx.slcp
+++ b/slc/apps/lock-app/wifi/lock-app-siwx.slcp
@@ -27,6 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/multi-sensor-app/thread/multi-sensor-app.slcp
+++ b/slc/apps/multi-sensor-app/thread/multi-sensor-app.slcp
@@ -34,7 +34,7 @@ component:
   - id: matter_provision_default
 
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/multi-sensor-app/thread/multi-sensor-app.slcp
+++ b/slc/apps/multi-sensor-app/thread/multi-sensor-app.slcp
@@ -34,6 +34,7 @@ component:
   - id: matter_provision_default
 
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/multi-sensor-app/wifi/multi-sensor-app-siwx.slcp
+++ b/slc/apps/multi-sensor-app/wifi/multi-sensor-app-siwx.slcp
@@ -27,7 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/multi-sensor-app/wifi/multi-sensor-app-siwx.slcp
+++ b/slc/apps/multi-sensor-app/wifi/multi-sensor-app-siwx.slcp
@@ -27,6 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/onoff-plug-app/thread/onoff-plug-app.slcp
+++ b/slc/apps/onoff-plug-app/thread/onoff-plug-app.slcp
@@ -34,6 +34,7 @@ component:
   - id: app_common
   - id: matter_provision_default
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_descriptor
   - id: matter_localization_configuration

--- a/slc/apps/onoff-plug-app/thread/onoff-plug-app.slcp
+++ b/slc/apps/onoff-plug-app/thread/onoff-plug-app.slcp
@@ -34,7 +34,7 @@ component:
   - id: app_common
   - id: matter_provision_default
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_descriptor
   - id: matter_localization_configuration

--- a/slc/apps/onoff-plug-app/wifi/onoff-plug-app-siwx.slcp
+++ b/slc/apps/onoff-plug-app/wifi/onoff-plug-app-siwx.slcp
@@ -28,7 +28,7 @@ component:
   - id: matter_provision_flash
 
   - id: matter_onoff_plug
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/onoff-plug-app/wifi/onoff-plug-app-siwx.slcp
+++ b/slc/apps/onoff-plug-app/wifi/onoff-plug-app-siwx.slcp
@@ -28,6 +28,7 @@ component:
   - id: matter_provision_flash
 
   - id: matter_onoff_plug
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/oven-app/wifi/oven-app-siwx.slcp
+++ b/slc/apps/oven-app/wifi/oven-app-siwx.slcp
@@ -27,7 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/oven-app/wifi/oven-app-siwx.slcp
+++ b/slc/apps/oven-app/wifi/oven-app-siwx.slcp
@@ -27,6 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/performance-test-app/thread/performance-test-app.slcp
+++ b/slc/apps/performance-test-app/thread/performance-test-app.slcp
@@ -36,7 +36,7 @@ component:
 
   #  - id: matter_lighting
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/performance-test-app/thread/performance-test-app.slcp
+++ b/slc/apps/performance-test-app/thread/performance-test-app.slcp
@@ -36,6 +36,7 @@ component:
 
   #  - id: matter_lighting
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/platform-template/thread/platform-template.slcp
+++ b/slc/apps/platform-template/thread/platform-template.slcp
@@ -31,7 +31,7 @@ component:
   - id: matter_platform_template
 
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/platform-template/thread/platform-template.slcp
+++ b/slc/apps/platform-template/thread/platform-template.slcp
@@ -31,6 +31,7 @@ component:
   - id: matter_platform_template
 
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/platform-template/wifi/platform-template-siwx.slcp
+++ b/slc/apps/platform-template/wifi/platform-template-siwx.slcp
@@ -26,6 +26,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/platform-template/wifi/platform-template-siwx.slcp
+++ b/slc/apps/platform-template/wifi/platform-template-siwx.slcp
@@ -26,7 +26,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/rangehood-app/thread/rangehood-app.slcp
+++ b/slc/apps/rangehood-app/thread/rangehood-app.slcp
@@ -34,6 +34,7 @@ component:
 
   - id: matter_rangehood
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/rangehood-app/thread/rangehood-app.slcp
+++ b/slc/apps/rangehood-app/thread/rangehood-app.slcp
@@ -34,7 +34,7 @@ component:
 
   - id: matter_rangehood
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/rangehood-app/wifi/rangehood-app-siwx.slcp
+++ b/slc/apps/rangehood-app/wifi/rangehood-app-siwx.slcp
@@ -27,7 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/rangehood-app/wifi/rangehood-app-siwx.slcp
+++ b/slc/apps/rangehood-app/wifi/rangehood-app-siwx.slcp
@@ -27,6 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/refrigerator-app/thread/refrigerator-app.slcp
+++ b/slc/apps/refrigerator-app/thread/refrigerator-app.slcp
@@ -34,7 +34,7 @@ component:
 
   - id: matter_refrigerator
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/refrigerator-app/thread/refrigerator-app.slcp
+++ b/slc/apps/refrigerator-app/thread/refrigerator-app.slcp
@@ -34,6 +34,7 @@ component:
 
   - id: matter_refrigerator
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/refrigerator-app/wifi/refrigerator-app-siwx.slcp
+++ b/slc/apps/refrigerator-app/wifi/refrigerator-app-siwx.slcp
@@ -27,7 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/refrigerator-app/wifi/refrigerator-app-siwx.slcp
+++ b/slc/apps/refrigerator-app/wifi/refrigerator-app-siwx.slcp
@@ -27,6 +27,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/thermostat/thread/thermostat.slcp
+++ b/slc/apps/thermostat/thread/thermostat.slcp
@@ -30,6 +30,7 @@ component:
 
   - id: matter_thermostat_app
   - id: app_common
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/thermostat/thread/thermostat.slcp
+++ b/slc/apps/thermostat/thread/thermostat.slcp
@@ -30,7 +30,7 @@ component:
 
   - id: matter_thermostat_app
   - id: app_common
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/thermostat/wifi/thermostat-917-ncp.slcp
+++ b/slc/apps/thermostat/wifi/thermostat-917-ncp.slcp
@@ -40,6 +40,7 @@ component:
   - id: psa_crypto_tls12_prf
     condition: [matter_aws]
     
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/thermostat/wifi/thermostat-917-ncp.slcp
+++ b/slc/apps/thermostat/wifi/thermostat-917-ncp.slcp
@@ -40,7 +40,7 @@ component:
   - id: psa_crypto_tls12_prf
     condition: [matter_aws]
     
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/thermostat/wifi/thermostat-siwx.slcp
+++ b/slc/apps/thermostat/wifi/thermostat-siwx.slcp
@@ -30,7 +30,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/thermostat/wifi/thermostat-siwx.slcp
+++ b/slc/apps/thermostat/wifi/thermostat-siwx.slcp
@@ -30,6 +30,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/window-app/thread/window-app.slcp
+++ b/slc/apps/window-app/thread/window-app.slcp
@@ -37,6 +37,7 @@ component:
   - id: matter_window
   - id: app_common
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/window-app/thread/window-app.slcp
+++ b/slc/apps/window-app/thread/window-app.slcp
@@ -37,7 +37,7 @@ component:
   - id: matter_window
   - id: app_common
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/window-app/wifi/window-app-917-ncp.slcp
+++ b/slc/apps/window-app/wifi/window-app-917-ncp.slcp
@@ -43,7 +43,7 @@ component:
   - id: psa_crypto_tls12_prf
     condition: [matter_aws]
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/window-app/wifi/window-app-917-ncp.slcp
+++ b/slc/apps/window-app/wifi/window-app-917-ncp.slcp
@@ -43,6 +43,7 @@ component:
   - id: psa_crypto_tls12_prf
     condition: [matter_aws]
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/window-app/wifi/window-app-siwx.slcp
+++ b/slc/apps/window-app/wifi/window-app-siwx.slcp
@@ -30,7 +30,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
-  - id: matter_zap_driven_dm
+  - id: matter_codegen_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/window-app/wifi/window-app-siwx.slcp
+++ b/slc/apps/window-app/wifi/window-app-siwx.slcp
@@ -30,6 +30,7 @@ component:
   - id: app_common
   - id: matter_provision_flash
 
+  - id: matter_zap_driven_dm
   - id: matter_access_control
   - id: matter_administrator_commissioning
   - id: matter_basic_information

--- a/slc/apps/zigbee-matter-light/thread/zigbee-matter-light.slcp
+++ b/slc/apps/zigbee-matter-light/thread/zigbee-matter-light.slcp
@@ -95,6 +95,7 @@ component:
   - { id: matter_shell }
   - { id: matter_power_source }
   - { id: app_common }
+  - { id: matter_zap_driven_dm }
   - { id: matter_provision_default }
   - { id: matter_log_uart }
   - { id: matter_zigbee_multiprotocol_common }

--- a/slc/apps/zigbee-matter-light/thread/zigbee-matter-light.slcp
+++ b/slc/apps/zigbee-matter-light/thread/zigbee-matter-light.slcp
@@ -95,7 +95,7 @@ component:
   - { id: matter_shell }
   - { id: matter_power_source }
   - { id: app_common }
-  - { id: matter_zap_driven_dm }
+  - { id: matter_codegen_dm }
   - { id: matter_provision_default }
   - { id: matter_log_uart }
   - { id: matter_zigbee_multiprotocol_common }

--- a/slc/component/matter-clusters/matter_access_control.slcc
+++ b/slc/component/matter-clusters/matter_access_control.slcc
@@ -15,6 +15,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/access-control-server/access-control-cluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/access-control-server/ArlEncoder.cpp
   - path: third_party/matter_sdk/src/app/clusters/access-control-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/access-control-server
     file_list:

--- a/slc/component/matter-clusters/matter_access_control.slcc
+++ b/slc/component/matter-clusters/matter_access_control.slcc
@@ -15,7 +15,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/access-control-server/access-control-cluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/access-control-server/ArlEncoder.cpp
   - path: third_party/matter_sdk/src/app/clusters/access-control-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/access-control-server
     file_list:

--- a/slc/component/matter-clusters/matter_actions.slcc
+++ b/slc/component/matter-clusters/matter_actions.slcc
@@ -14,7 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/actions-server/ActionsCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/actions-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/actions-server
     file_list:

--- a/slc/component/matter-clusters/matter_actions.slcc
+++ b/slc/component/matter-clusters/matter_actions.slcc
@@ -14,6 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/actions-server/ActionsCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/actions-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/actions-server
     file_list:

--- a/slc/component/matter-clusters/matter_actions.slcc
+++ b/slc/component/matter-clusters/matter_actions.slcc
@@ -23,6 +23,7 @@ include:
       - path: ActionsDelegate.h
       - path: ActionsStructs.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
 template_contribution:
   - name: component_catalog
     value: matter_actions

--- a/slc/component/matter-clusters/matter_administrator_commissioning.slcc
+++ b/slc/component/matter-clusters/matter_administrator_commissioning.slcc
@@ -15,6 +15,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/administrator-commissioning-server/AdministratorCommissioningCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/administrator-commissioning-server/AdministratorCommissioningLogic.cpp
   - path: third_party/matter_sdk/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/administrator-commissioning-server
     file_list:

--- a/slc/component/matter-clusters/matter_administrator_commissioning.slcc
+++ b/slc/component/matter-clusters/matter_administrator_commissioning.slcc
@@ -15,7 +15,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/administrator-commissioning-server/AdministratorCommissioningCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/administrator-commissioning-server/AdministratorCommissioningLogic.cpp
   - path: third_party/matter_sdk/src/app/clusters/administrator-commissioning-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/administrator-commissioning-server
     file_list:

--- a/slc/component/matter-clusters/matter_air_quality.slcc
+++ b/slc/component/matter-clusters/matter_air_quality.slcc
@@ -14,7 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/air-quality-server/AirQualityCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/air-quality-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/air-quality-server
     file_list:

--- a/slc/component/matter-clusters/matter_air_quality.slcc
+++ b/slc/component/matter-clusters/matter_air_quality.slcc
@@ -14,6 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/air-quality-server/AirQualityCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/air-quality-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/air-quality-server
     file_list:

--- a/slc/component/matter-clusters/matter_air_quality.slcc
+++ b/slc/component/matter-clusters/matter_air_quality.slcc
@@ -21,6 +21,7 @@ include:
       - path: air-quality-server.h
       - path: AirQualityCluster.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
 config_file:
   - path: third_party/matter_sdk/examples/air-quality-sensor-app/silabs/include/AirQualityConfig.h
     file_id: matter_air_quality_config

--- a/slc/component/matter-clusters/matter_basic_information.slcc
+++ b/slc/component/matter-clusters/matter_basic_information.slcc
@@ -13,12 +13,14 @@ provides:
   - name: matter_basic_information
 source:
   - path: third_party/matter_sdk/src/app/clusters/basic-information/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/basic-information
     file_list:
       - path: BasicInformationCluster.h
       - path: BasicInformationOptionalAttributes.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven]
       - path: DeviceLayerBasicInformationPolicy.h
       - path: PolicyBased.h
 template_contribution:

--- a/slc/component/matter-clusters/matter_basic_information.slcc
+++ b/slc/component/matter-clusters/matter_basic_information.slcc
@@ -20,6 +20,7 @@ include:
       - path: BasicInformationCluster.h
       - path: BasicInformationOptionalAttributes.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: DeviceLayerBasicInformationPolicy.h
       - path: PolicyBased.h
 template_contribution:

--- a/slc/component/matter-clusters/matter_basic_information.slcc
+++ b/slc/component/matter-clusters/matter_basic_information.slcc
@@ -20,7 +20,6 @@ include:
       - path: BasicInformationCluster.h
       - path: BasicInformationOptionalAttributes.h
       - path: CodegenIntegration.h
-        unless: [matter_code_driven]
       - path: DeviceLayerBasicInformationPolicy.h
       - path: PolicyBased.h
 template_contribution:

--- a/slc/component/matter-clusters/matter_basic_information.slcc
+++ b/slc/component/matter-clusters/matter_basic_information.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_basic_information
 source:
   - path: third_party/matter_sdk/src/app/clusters/basic-information/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/basic-information
     file_list:

--- a/slc/component/matter-clusters/matter_bindings.slcc
+++ b/slc/component/matter-clusters/matter_bindings.slcc
@@ -16,6 +16,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/bindings/BindingCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/bindings/BindingManager.cpp
   - path: third_party/matter_sdk/src/app/clusters/bindings/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/bindings/PendingNotificationMap.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/bindings

--- a/slc/component/matter-clusters/matter_bindings.slcc
+++ b/slc/component/matter-clusters/matter_bindings.slcc
@@ -16,7 +16,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/bindings/BindingCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/bindings/BindingManager.cpp
   - path: third_party/matter_sdk/src/app/clusters/bindings/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/bindings/PendingNotificationMap.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/bindings

--- a/slc/component/matter-clusters/matter_boolean_state.slcc
+++ b/slc/component/matter-clusters/matter_boolean_state.slcc
@@ -14,7 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-server/BooleanStateCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-server
     file_list:

--- a/slc/component/matter-clusters/matter_boolean_state.slcc
+++ b/slc/component/matter-clusters/matter_boolean_state.slcc
@@ -20,6 +20,7 @@ include:
     file_list:
       - path: BooleanStateCluster.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
 template_contribution:
   - name: component_catalog
     value: matter_boolean_state

--- a/slc/component/matter-clusters/matter_boolean_state.slcc
+++ b/slc/component/matter-clusters/matter_boolean_state.slcc
@@ -14,6 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-server/BooleanStateCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-server
     file_list:

--- a/slc/component/matter-clusters/matter_boolean_state_configuration.slcc
+++ b/slc/component/matter-clusters/matter_boolean_state_configuration.slcc
@@ -24,6 +24,7 @@ include:
       - path: BooleanStateConfigurationCluster.h
       - path: BooleanStateConfigurationTestEventTriggerHandler.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
 template_contribution:
   - name: component_catalog
     value: matter_boolean_state_configuration

--- a/slc/component/matter-clusters/matter_boolean_state_configuration.slcc
+++ b/slc/component/matter-clusters/matter_boolean_state_configuration.slcc
@@ -15,7 +15,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationTestEventTriggerHandler.cpp
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-configuration-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-configuration-server
     file_list:

--- a/slc/component/matter-clusters/matter_boolean_state_configuration.slcc
+++ b/slc/component/matter-clusters/matter_boolean_state_configuration.slcc
@@ -15,6 +15,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-configuration-server/BooleanStateConfigurationTestEventTriggerHandler.cpp
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-configuration-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/boolean-state-configuration-server
     file_list:

--- a/slc/component/matter-clusters/matter_bridged_device_basic_information.slcc
+++ b/slc/component/matter-clusters/matter_bridged_device_basic_information.slcc
@@ -14,6 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/bridged-device-basic-information-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/bridged-device-basic-information-server
     file_list:

--- a/slc/component/matter-clusters/matter_bridged_device_basic_information.slcc
+++ b/slc/component/matter-clusters/matter_bridged_device_basic_information.slcc
@@ -14,7 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/bridged-device-basic-information-server/BridgedDeviceBasicInformationCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/bridged-device-basic-information-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/bridged-device-basic-information-server
     file_list:

--- a/slc/component/matter-clusters/matter_camera_av_settings_user_level_management.slcc
+++ b/slc/component/matter-clusters/matter_camera_av_settings_user_level_management.slcc
@@ -15,7 +15,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.cpp
   - path: third_party/matter_sdk/src/app/clusters/camera-av-settings-user-level-management-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/camera-av-settings-user-level-management-server
     file_list:

--- a/slc/component/matter-clusters/matter_camera_av_settings_user_level_management.slcc
+++ b/slc/component/matter-clusters/matter_camera_av_settings_user_level_management.slcc
@@ -15,6 +15,7 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/camera-av-settings-user-level-management-server/CameraAvSettingsUserLevelManagementLogic.cpp
   - path: third_party/matter_sdk/src/app/clusters/camera-av-settings-user-level-management-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/camera-av-settings-user-level-management-server
     file_list:

--- a/slc/component/matter-clusters/matter_chime.slcc
+++ b/slc/component/matter-clusters/matter_chime.slcc
@@ -14,7 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/chime-server/ChimeCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/chime-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/chime-server/MigrateChimeServerStorage.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/chime-server

--- a/slc/component/matter-clusters/matter_chime.slcc
+++ b/slc/component/matter-clusters/matter_chime.slcc
@@ -22,6 +22,7 @@ include:
       - path: chime-server.h
       - path: ChimeCluster.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: MigrateChimeServerStorage.h
 template_contribution:
   - name: component_catalog

--- a/slc/component/matter-clusters/matter_chime.slcc
+++ b/slc/component/matter-clusters/matter_chime.slcc
@@ -14,6 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/chime-server/ChimeCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/chime-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/chime-server/MigrateChimeServerStorage.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/chime-server

--- a/slc/component/matter-clusters/matter_closure_control.slcc
+++ b/slc/component/matter-clusters/matter_closure_control.slcc
@@ -14,6 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/closure-control-server/ClosureControlCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/closure-control-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/closure-control-server
     file_list:

--- a/slc/component/matter-clusters/matter_closure_control.slcc
+++ b/slc/component/matter-clusters/matter_closure_control.slcc
@@ -14,7 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/closure-control-server/ClosureControlCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/closure-control-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/closure-control-server
     file_list:

--- a/slc/component/matter-clusters/matter_closure_control.slcc
+++ b/slc/component/matter-clusters/matter_closure_control.slcc
@@ -22,6 +22,7 @@ include:
       - path: ClosureControlClusterDelegate.h
       - path: ClosureControlClusterObjects.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
 template_contribution:
   - name: component_catalog
     value: matter_closure_control

--- a/slc/component/matter-clusters/matter_closure_dimension.slcc
+++ b/slc/component/matter-clusters/matter_closure_dimension.slcc
@@ -11,6 +11,8 @@ metadata:
     license: "Apache 2.0"
 provides:
   - name: matter_closure_dimension
+requires:
+  - name: matter_cluster_building_blocks
 source:
   - path: third_party/matter_sdk/src/app/clusters/closure-dimension-server/ClosureDimensionCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/closure-dimension-server/ClosureDimensionClusterMatterContext.cpp

--- a/slc/component/matter-clusters/matter_closure_dimension.slcc
+++ b/slc/component/matter-clusters/matter_closure_dimension.slcc
@@ -11,8 +11,6 @@ metadata:
     license: "Apache 2.0"
 provides:
   - name: matter_closure_dimension
-requires:
-  - name: matter_cluster_building_blocks
 source:
   - path: third_party/matter_sdk/src/app/clusters/closure-dimension-server/ClosureDimensionCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/closure-dimension-server/ClosureDimensionClusterMatterContext.cpp
@@ -27,6 +25,7 @@ include:
       - path: ClosureDimensionClusterDelegate.h
       - path: ClosureDimensionClusterMatterContext.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: GenericDimensionState.h
 template_contribution:
   - name: component_catalog

--- a/slc/component/matter-clusters/matter_code_driven.slcc
+++ b/slc/component/matter-clusters/matter_code_driven.slcc
@@ -1,0 +1,18 @@
+category: Clusters|Config
+description: >
+  Disable the need for the codegen Integration code when using code driven only implementation
+id: matter_code_driven
+package: matter
+label: Matter Code Driven
+quality: production
+metadata:
+  sbom:
+    license: "Apache 2.0"
+provides:
+  - name: matter_code_driven
+define:
+  - name: SL_MATTER_USE_CODE_DRIVEN_DATA_MODEL
+    value: '1'
+template_contribution:
+  - name: component_catalog
+    value: matter_code_driven

--- a/slc/component/matter-clusters/matter_commissioner_control.slcc
+++ b/slc/component/matter-clusters/matter_commissioner_control.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_commissioner_control
 source:
   - path: third_party/matter_sdk/src/app/clusters/commissioner-control-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/commissioner-control-server/CommissionerControlCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/commissioner-control-server

--- a/slc/component/matter-clusters/matter_commissioner_control.slcc
+++ b/slc/component/matter-clusters/matter_commissioner_control.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/commissioner-control-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: commissioner-control-server.h
       - path: CommissionerControlCluster.h
       - path: Delegate.h

--- a/slc/component/matter-clusters/matter_commissioner_control.slcc
+++ b/slc/component/matter-clusters/matter_commissioner_control.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_commissioner_control
 source:
   - path: third_party/matter_sdk/src/app/clusters/commissioner-control-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/commissioner-control-server/CommissionerControlCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/commissioner-control-server

--- a/slc/component/matter-clusters/matter_descriptor.slcc
+++ b/slc/component/matter-clusters/matter_descriptor.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_descriptor
 source:
   - path: third_party/matter_sdk/src/app/clusters/descriptor/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/descriptor/DescriptorCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/descriptor

--- a/slc/component/matter-clusters/matter_descriptor.slcc
+++ b/slc/component/matter-clusters/matter_descriptor.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_descriptor
 source:
   - path: third_party/matter_sdk/src/app/clusters/descriptor/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/descriptor/DescriptorCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/descriptor

--- a/slc/component/matter-clusters/matter_device_energy_management.slcc
+++ b/slc/component/matter-clusters/matter_device_energy_management.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_device_energy_management
 source:
   - path: third_party/matter_sdk/src/app/clusters/device-energy-management-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/device-energy-management-server/DeviceEnergyManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/device-energy-management-server

--- a/slc/component/matter-clusters/matter_device_energy_management.slcc
+++ b/slc/component/matter-clusters/matter_device_energy_management.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/device-energy-management-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: device-energy-management-server.h
       - path: DeviceEnergyManagementCluster.h
       - path: DeviceEnergyManagementDelegate.h

--- a/slc/component/matter-clusters/matter_device_energy_management.slcc
+++ b/slc/component/matter-clusters/matter_device_energy_management.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_device_energy_management
 source:
   - path: third_party/matter_sdk/src/app/clusters/device-energy-management-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/device-energy-management-server/DeviceEnergyManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/device-energy-management-server

--- a/slc/component/matter-clusters/matter_diagnostic_logs.slcc
+++ b/slc/component/matter-clusters/matter_diagnostic_logs.slcc
@@ -14,6 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/diagnostic-logs-server/BDXDiagnosticLogsProvider.cpp
   - path: third_party/matter_sdk/src/app/clusters/diagnostic-logs-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/diagnostic-logs-server/DiagnosticLogsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/diagnostic-logs-server

--- a/slc/component/matter-clusters/matter_diagnostic_logs.slcc
+++ b/slc/component/matter-clusters/matter_diagnostic_logs.slcc
@@ -14,7 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/diagnostic-logs-server/BDXDiagnosticLogsProvider.cpp
   - path: third_party/matter_sdk/src/app/clusters/diagnostic-logs-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/diagnostic-logs-server/DiagnosticLogsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/diagnostic-logs-server

--- a/slc/component/matter-clusters/matter_diagnostic_logs.slcc
+++ b/slc/component/matter-clusters/matter_diagnostic_logs.slcc
@@ -21,6 +21,7 @@ include:
     file_list:
       - path: BDXDiagnosticLogsProvider.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: diagnostic-logs-server.h
       - path: DiagnosticLogsCluster.h
       - path: DiagnosticLogsProviderDelegate.h

--- a/slc/component/matter-clusters/matter_electrical_energy_measurement.slcc
+++ b/slc/component/matter-clusters/matter_electrical_energy_measurement.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_electrical_energy_measurement
 source:
   - path: third_party/matter_sdk/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/electrical-energy-measurement-server

--- a/slc/component/matter-clusters/matter_electrical_energy_measurement.slcc
+++ b/slc/component/matter-clusters/matter_electrical_energy_measurement.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_electrical_energy_measurement
 source:
   - path: third_party/matter_sdk/src/app/clusters/electrical-energy-measurement-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/electrical-energy-measurement-server/ElectricalEnergyMeasurementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/electrical-energy-measurement-server

--- a/slc/component/matter-clusters/matter_electrical_energy_measurement.slcc
+++ b/slc/component/matter-clusters/matter_electrical_energy_measurement.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/electrical-energy-measurement-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: electrical-energy-measurement-server.h
       - path: ElectricalEnergyMeasurementCluster.h
       - path: EnergyReportingTestEventTriggerHandler.h

--- a/slc/component/matter-clusters/matter_electrical_power_measurement.slcc
+++ b/slc/component/matter-clusters/matter_electrical_power_measurement.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/electrical-power-measurement-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: electrical-power-measurement-server.h
       - path: ElectricalPowerMeasurementCluster.h
       - path: ElectricalPowerMeasurementDelegate.h

--- a/slc/component/matter-clusters/matter_electrical_power_measurement.slcc
+++ b/slc/component/matter-clusters/matter_electrical_power_measurement.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_electrical_power_measurement
 source:
   - path: third_party/matter_sdk/src/app/clusters/electrical-power-measurement-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/electrical-power-measurement-server/ElectricalPowerMeasurementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/electrical-power-measurement-server

--- a/slc/component/matter-clusters/matter_electrical_power_measurement.slcc
+++ b/slc/component/matter-clusters/matter_electrical_power_measurement.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_electrical_power_measurement
 source:
   - path: third_party/matter_sdk/src/app/clusters/electrical-power-measurement-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/electrical-power-measurement-server/ElectricalPowerMeasurementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/electrical-power-measurement-server

--- a/slc/component/matter-clusters/matter_energy_evse.slcc
+++ b/slc/component/matter-clusters/matter_energy_evse.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_energy_evse
 source:
   - path: third_party/matter_sdk/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/energy-evse-server

--- a/slc/component/matter-clusters/matter_energy_evse.slcc
+++ b/slc/component/matter-clusters/matter_energy_evse.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/energy-evse-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: Constants.h
       - path: energy-evse-server.h
       - path: EnergyEvseCluster.h

--- a/slc/component/matter-clusters/matter_energy_evse.slcc
+++ b/slc/component/matter-clusters/matter_energy_evse.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_energy_evse
 source:
   - path: third_party/matter_sdk/src/app/clusters/energy-evse-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/energy-evse-server/EnergyEvseCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/energy-evse-server

--- a/slc/component/matter-clusters/matter_ethernet_network_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_ethernet_network_diagnostics.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_ethernet_network_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/ethernet-network-diagnostics-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/ethernet-network-diagnostics-server/EthernetDiagnosticsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/ethernet-network-diagnostics-server

--- a/slc/component/matter-clusters/matter_ethernet_network_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_ethernet_network_diagnostics.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_ethernet_network_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/ethernet-network-diagnostics-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/ethernet-network-diagnostics-server/EthernetDiagnosticsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/ethernet-network-diagnostics-server

--- a/slc/component/matter-clusters/matter_fixed_label.slcc
+++ b/slc/component/matter-clusters/matter_fixed_label.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_fixed_label
 source:
   - path: third_party/matter_sdk/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/fixed-label-server

--- a/slc/component/matter-clusters/matter_fixed_label.slcc
+++ b/slc/component/matter-clusters/matter_fixed_label.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_fixed_label
 source:
   - path: third_party/matter_sdk/src/app/clusters/fixed-label-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/fixed-label-server/FixedLabelCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/fixed-label-server

--- a/slc/component/matter-clusters/matter_general_commissioning.slcc
+++ b/slc/component/matter-clusters/matter_general_commissioning.slcc
@@ -20,6 +20,7 @@ include:
     file_list:
       - path: BreadCrumbTracker.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: GeneralCommissioningCluster.h
 template_contribution:
   - name: component_catalog

--- a/slc/component/matter-clusters/matter_general_commissioning.slcc
+++ b/slc/component/matter-clusters/matter_general_commissioning.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_general_commissioning
 source:
   - path: third_party/matter_sdk/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/general-commissioning-server/GeneralCommissioningCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/general-commissioning-server

--- a/slc/component/matter-clusters/matter_general_commissioning.slcc
+++ b/slc/component/matter-clusters/matter_general_commissioning.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_general_commissioning
 source:
   - path: third_party/matter_sdk/src/app/clusters/general-commissioning-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/general-commissioning-server/GeneralCommissioningCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/general-commissioning-server

--- a/slc/component/matter-clusters/matter_general_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_general_diagnostics.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_general_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server/GeneralDiagnosticsCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerHandler.cpp
 include:

--- a/slc/component/matter-clusters/matter_general_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_general_diagnostics.slcc
@@ -15,13 +15,12 @@ source:
   - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
     unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server/GeneralDiagnosticsCluster.cpp
-  - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerHandler.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: GeneralDiagnosticsCluster.h
-      - path: GenericFaultTestEventTriggerHandler.h
 template_contribution:
   - name: component_catalog
     value: matter_general_diagnostics

--- a/slc/component/matter-clusters/matter_general_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_general_diagnostics.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_general_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server/GeneralDiagnosticsCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/general-diagnostics-server/GenericFaultTestEventTriggerHandler.cpp
 include:

--- a/slc/component/matter-clusters/matter_group_key_mgmt.slcc
+++ b/slc/component/matter-clusters/matter_group_key_mgmt.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_group_key_mgmt
 source:
   - path: third_party/matter_sdk/src/app/clusters/group-key-mgmt-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/group-key-mgmt-server

--- a/slc/component/matter-clusters/matter_group_key_mgmt.slcc
+++ b/slc/component/matter-clusters/matter_group_key_mgmt.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_group_key_mgmt
 source:
   - path: third_party/matter_sdk/src/app/clusters/group-key-mgmt-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/group-key-mgmt-server/GroupKeyManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/group-key-mgmt-server

--- a/slc/component/matter-clusters/matter_groupcast.slcc
+++ b/slc/component/matter-clusters/matter_groupcast.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_groupcast
 source:
   - path: third_party/matter_sdk/src/app/clusters/groupcast/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/groupcast/GroupcastCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/groupcast

--- a/slc/component/matter-clusters/matter_groupcast.slcc
+++ b/slc/component/matter-clusters/matter_groupcast.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_groupcast
 source:
   - path: third_party/matter_sdk/src/app/clusters/groupcast/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/groupcast/GroupcastCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/groupcast

--- a/slc/component/matter-clusters/matter_groups.slcc
+++ b/slc/component/matter-clusters/matter_groups.slcc
@@ -15,6 +15,7 @@ requires:
   - name: matter_scenes
 source:
   - path: third_party/matter_sdk/src/app/clusters/groups-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/groups-server/GroupsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/groups-server

--- a/slc/component/matter-clusters/matter_groups.slcc
+++ b/slc/component/matter-clusters/matter_groups.slcc
@@ -15,7 +15,7 @@ requires:
   - name: matter_scenes
 source:
   - path: third_party/matter_sdk/src/app/clusters/groups-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/groups-server/GroupsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/groups-server

--- a/slc/component/matter-clusters/matter_icd_management.slcc
+++ b/slc/component/matter-clusters/matter_icd_management.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_icd_management
 source:
   - path: third_party/matter_sdk/src/app/clusters/icd-management-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/icd-management-server/ICDManagementCluster.cpp
   - path: third_party/matter_sdk/src/app/icd/server/ICDConfigurationData.cpp
   - path: third_party/matter_sdk/src/app/icd/server/ICDManager.cpp

--- a/slc/component/matter-clusters/matter_icd_management.slcc
+++ b/slc/component/matter-clusters/matter_icd_management.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_icd_management
 source:
   - path: third_party/matter_sdk/src/app/clusters/icd-management-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/icd-management-server/ICDManagementCluster.cpp
   - path: third_party/matter_sdk/src/app/icd/server/ICDConfigurationData.cpp
   - path: third_party/matter_sdk/src/app/icd/server/ICDManager.cpp

--- a/slc/component/matter-clusters/matter_identify.slcc
+++ b/slc/component/matter-clusters/matter_identify.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_identify
 source:
   - path: third_party/matter_sdk/src/app/clusters/identify-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/identify-server/IdentifyCluster.cpp
 include:
   - path: third_party/matter_sdk/src/lib/support

--- a/slc/component/matter-clusters/matter_identify.slcc
+++ b/slc/component/matter-clusters/matter_identify.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_identify
 source:
   - path: third_party/matter_sdk/src/app/clusters/identify-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/identify-server/IdentifyCluster.cpp
 include:
   - path: third_party/matter_sdk/src/lib/support

--- a/slc/component/matter-clusters/matter_identify.slcc
+++ b/slc/component/matter-clusters/matter_identify.slcc
@@ -16,6 +16,9 @@ source:
     unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/identify-server/IdentifyCluster.cpp
 include:
+  - path: third_party/matter_sdk/src/lib/support
+    file_list:
+      - path: TimerDelegate.h
   - path: third_party/matter_sdk/src/app/clusters/identify-server
     file_list:
       - path: CodegenIntegration.h

--- a/slc/component/matter-clusters/matter_identify.slcc
+++ b/slc/component/matter-clusters/matter_identify.slcc
@@ -16,12 +16,10 @@ source:
     unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/identify-server/IdentifyCluster.cpp
 include:
-  - path: third_party/matter_sdk/src/lib/support
-    file_list:
-      - path: TimerDelegate.h
   - path: third_party/matter_sdk/src/app/clusters/identify-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: identify-server.h
       - path: IdentifyCluster.h
       - path: IdentifyIntegrationDelegate.h

--- a/slc/component/matter-clusters/matter_illuminance_measurement.slcc
+++ b/slc/component/matter-clusters/matter_illuminance_measurement.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/illuminance-measurement-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: IlluminanceMeasurementCluster.h
 template_contribution:
   - name: component_catalog

--- a/slc/component/matter-clusters/matter_illuminance_measurement.slcc
+++ b/slc/component/matter-clusters/matter_illuminance_measurement.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_illuminance_measurement
 source:
   - path: third_party/matter_sdk/src/app/clusters/illuminance-measurement-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/illuminance-measurement-server/IlluminanceMeasurementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/illuminance-measurement-server

--- a/slc/component/matter-clusters/matter_illuminance_measurement.slcc
+++ b/slc/component/matter-clusters/matter_illuminance_measurement.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_illuminance_measurement
 source:
   - path: third_party/matter_sdk/src/app/clusters/illuminance-measurement-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/illuminance-measurement-server/IlluminanceMeasurementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/illuminance-measurement-server

--- a/slc/component/matter-clusters/matter_localization_configuration.slcc
+++ b/slc/component/matter-clusters/matter_localization_configuration.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_localization_configuration
 source:
   - path: third_party/matter_sdk/src/app/clusters/localization-configuration-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/localization-configuration-server

--- a/slc/component/matter-clusters/matter_localization_configuration.slcc
+++ b/slc/component/matter-clusters/matter_localization_configuration.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_localization_configuration
 source:
   - path: third_party/matter_sdk/src/app/clusters/localization-configuration-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/localization-configuration-server/LocalizationConfigurationCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/localization-configuration-server

--- a/slc/component/matter-clusters/matter_microwave_oven_control.slcc
+++ b/slc/component/matter-clusters/matter_microwave_oven_control.slcc
@@ -17,6 +17,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/microwave-oven-control-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: Delegate.h
       - path: microwave-oven-control-server.h
 template_contribution:

--- a/slc/component/matter-clusters/matter_network_commissioning.slcc
+++ b/slc/component/matter-clusters/matter_network_commissioning.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_network_commissioning
 source:
   - path: third_party/matter_sdk/src/app/clusters/network-commissioning/CodegenInstance.cpp
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/network-commissioning/NetworkCommissioningCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/network-commissioning/ThreadScanResponse.cpp
   - path: third_party/matter_sdk/src/app/clusters/network-commissioning/WifiScanResponse.cpp

--- a/slc/component/matter-clusters/matter_network_commissioning.slcc
+++ b/slc/component/matter-clusters/matter_network_commissioning.slcc
@@ -21,6 +21,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/network-commissioning
     file_list:
       - path: CodegenInstance.h
+        unless: [matter_code_driven_dm]
       - path: constants.h
       - path: network-commissioning.h
       - path: NetworkCommissioningCluster.h

--- a/slc/component/matter-clusters/matter_occupancy_sensor.slcc
+++ b/slc/component/matter-clusters/matter_occupancy_sensor.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_occupancy_sensor
 source:
   - path: third_party/matter_sdk/src/app/clusters/occupancy-sensor-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/occupancy-sensor-server

--- a/slc/component/matter-clusters/matter_occupancy_sensor.slcc
+++ b/slc/component/matter-clusters/matter_occupancy_sensor.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/occupancy-sensor-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: OccupancySensingCluster.h
 template_contribution:
   - name: component_catalog

--- a/slc/component/matter-clusters/matter_occupancy_sensor.slcc
+++ b/slc/component/matter-clusters/matter_occupancy_sensor.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_occupancy_sensor
 source:
   - path: third_party/matter_sdk/src/app/clusters/occupancy-sensor-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/occupancy-sensor-server/OccupancySensingCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/occupancy-sensor-server

--- a/slc/component/matter-clusters/matter_operational_credentials.slcc
+++ b/slc/component/matter-clusters/matter_operational_credentials.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_operational_credentials
 source:
   - path: third_party/matter_sdk/src/app/clusters/operational-credentials-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/operational-credentials-server

--- a/slc/component/matter-clusters/matter_operational_credentials.slcc
+++ b/slc/component/matter-clusters/matter_operational_credentials.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_operational_credentials
 source:
   - path: third_party/matter_sdk/src/app/clusters/operational-credentials-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/operational-credentials-server/OperationalCredentialsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/operational-credentials-server

--- a/slc/component/matter-clusters/matter_ota_provider.slcc
+++ b/slc/component/matter-clusters/matter_ota_provider.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/ota-provider
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: DefaultOTAProviderUserConsent.h
       - path: ota-provider-delegate.h
       - path: OTAProviderCluster.h

--- a/slc/component/matter-clusters/matter_ota_provider.slcc
+++ b/slc/component/matter-clusters/matter_ota_provider.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_ota_provider
 source:
   - path: third_party/matter_sdk/src/app/clusters/ota-provider/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/ota-provider/OTAProviderCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/ota-provider

--- a/slc/component/matter-clusters/matter_ota_provider.slcc
+++ b/slc/component/matter-clusters/matter_ota_provider.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_ota_provider
 source:
   - path: third_party/matter_sdk/src/app/clusters/ota-provider/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/ota-provider/OTAProviderCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/ota-provider

--- a/slc/component/matter-clusters/matter_power_source.slcc
+++ b/slc/component/matter-clusters/matter_power_source.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_power_source
 source:
   - path: third_party/matter_sdk/src/app/clusters/power-source-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
 include:
   - path: third_party/matter_sdk/src/app/clusters/power-source-server
     file_list:

--- a/slc/component/matter-clusters/matter_power_source.slcc
+++ b/slc/component/matter-clusters/matter_power_source.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_power_source
 source:
   - path: third_party/matter_sdk/src/app/clusters/power-source-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 include:
   - path: third_party/matter_sdk/src/app/clusters/power-source-server
     file_list:

--- a/slc/component/matter-clusters/matter_power_source.slcc
+++ b/slc/component/matter-clusters/matter_power_source.slcc
@@ -18,6 +18,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/power-source-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: power-source-server.h
 template_contribution:
   - name: component_catalog

--- a/slc/component/matter-clusters/matter_power_topology.slcc
+++ b/slc/component/matter-clusters/matter_power_topology.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/power-topology-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: power-topology-server.h
       - path: PowerTopologyCluster.h
       - path: PowerTopologyDelegate.h

--- a/slc/component/matter-clusters/matter_power_topology.slcc
+++ b/slc/component/matter-clusters/matter_power_topology.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_power_topology
 source:
   - path: third_party/matter_sdk/src/app/clusters/power-topology-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/power-topology-server/PowerTopologyCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/power-topology-server

--- a/slc/component/matter-clusters/matter_power_topology.slcc
+++ b/slc/component/matter-clusters/matter_power_topology.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_power_topology
 source:
   - path: third_party/matter_sdk/src/app/clusters/power-topology-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/power-topology-server/PowerTopologyCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/power-topology-server

--- a/slc/component/matter-clusters/matter_push_av_stream_transport.slcc
+++ b/slc/component/matter-clusters/matter_push_av_stream_transport.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_push_av_stream_transport
 source:
   - path: third_party/matter_sdk/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
 include:

--- a/slc/component/matter-clusters/matter_push_av_stream_transport.slcc
+++ b/slc/component/matter-clusters/matter_push_av_stream_transport.slcc
@@ -20,6 +20,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/push-av-stream-transport-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: constants.h
       - path: push-av-stream-transport-delegate.h
       - path: push-av-stream-transport-storage.h

--- a/slc/component/matter-clusters/matter_push_av_stream_transport.slcc
+++ b/slc/component/matter-clusters/matter_push_av_stream_transport.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_push_av_stream_transport
 source:
   - path: third_party/matter_sdk/src/app/clusters/push-av-stream-transport-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/push-av-stream-transport-server/PushAVStreamTransportLogic.cpp
 include:

--- a/slc/component/matter-clusters/matter_resource_monitoring.slcc
+++ b/slc/component/matter-clusters/matter_resource_monitoring.slcc
@@ -20,6 +20,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/resource-monitoring-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: replacement-product-list-manager.h
       - path: resource-monitoring-cluster-objects.h
       - path: resource-monitoring-server.h

--- a/slc/component/matter-clusters/matter_resource_monitoring.slcc
+++ b/slc/component/matter-clusters/matter_resource_monitoring.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_resource_monitoring
 source:
   - path: third_party/matter_sdk/src/app/clusters/resource-monitoring-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/resource-monitoring-server/resource-monitoring-cluster-objects.cpp
   - path: third_party/matter_sdk/src/app/clusters/resource-monitoring-server/ResourceMonitoringCluster.cpp
 include:

--- a/slc/component/matter-clusters/matter_resource_monitoring.slcc
+++ b/slc/component/matter-clusters/matter_resource_monitoring.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_resource_monitoring
 source:
   - path: third_party/matter_sdk/src/app/clusters/resource-monitoring-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/resource-monitoring-server/resource-monitoring-cluster-objects.cpp
   - path: third_party/matter_sdk/src/app/clusters/resource-monitoring-server/ResourceMonitoringCluster.cpp
 include:

--- a/slc/component/matter-clusters/matter_scenes.slcc
+++ b/slc/component/matter-clusters/matter_scenes.slcc
@@ -16,7 +16,7 @@ requires:
 source:
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/CodegenAttributeValuePairValidator.cpp
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/ExtensionFieldSetsImpl.cpp
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/SceneHandlerImpl.cpp
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/ScenesManagementCluster.cpp

--- a/slc/component/matter-clusters/matter_scenes.slcc
+++ b/slc/component/matter-clusters/matter_scenes.slcc
@@ -11,8 +11,6 @@ metadata:
     license: "Apache 2.0"
 provides:
   - name: matter_scenes
-requires:
-  - name: matter_fabric_table
 source:
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/CodegenAttributeValuePairValidator.cpp
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/CodegenIntegration.cpp
@@ -28,6 +26,7 @@ include:
       - path: CodegenAttributeValuePairValidator.h
       - path: CodegenEndpointToIndex.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: Constants.h
       - path: ExtensionFieldSets.h
       - path: ExtensionFieldSetsImpl.h

--- a/slc/component/matter-clusters/matter_scenes.slcc
+++ b/slc/component/matter-clusters/matter_scenes.slcc
@@ -16,6 +16,7 @@ requires:
 source:
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/CodegenAttributeValuePairValidator.cpp
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/ExtensionFieldSetsImpl.cpp
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/SceneHandlerImpl.cpp
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/ScenesManagementCluster.cpp

--- a/slc/component/matter-clusters/matter_scenes.slcc
+++ b/slc/component/matter-clusters/matter_scenes.slcc
@@ -11,6 +11,8 @@ metadata:
     license: "Apache 2.0"
 provides:
   - name: matter_scenes
+requires:
+  - name: matter_fabric_table
 source:
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/CodegenAttributeValuePairValidator.cpp
   - path: third_party/matter_sdk/src/app/clusters/scenes-server/CodegenIntegration.cpp

--- a/slc/component/matter-clusters/matter_software_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_software_diagnostics.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_software_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/software-diagnostics-server/software-fault-listener.cpp
   - path: third_party/matter_sdk/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsCluster.cpp
 include:

--- a/slc/component/matter-clusters/matter_software_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_software_diagnostics.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_software_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/software-diagnostics-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/software-diagnostics-server/software-fault-listener.cpp
   - path: third_party/matter_sdk/src/app/clusters/software-diagnostics-server/SoftwareDiagnosticsCluster.cpp
 include:

--- a/slc/component/matter-clusters/matter_switch.slcc
+++ b/slc/component/matter-clusters/matter_switch.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/switch-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: switch-server.h
       - path: SwitchCluster.h
 template_contribution:

--- a/slc/component/matter-clusters/matter_switch.slcc
+++ b/slc/component/matter-clusters/matter_switch.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_switch
 source:
   - path: third_party/matter_sdk/src/app/clusters/switch-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/switch-server/SwitchCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/switch-server

--- a/slc/component/matter-clusters/matter_switch.slcc
+++ b/slc/component/matter-clusters/matter_switch.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_switch
 source:
   - path: third_party/matter_sdk/src/app/clusters/switch-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/switch-server/SwitchCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/switch-server

--- a/slc/component/matter-clusters/matter_temperature_control.slcc
+++ b/slc/component/matter-clusters/matter_temperature_control.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/temperature-control-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: supported-temperature-levels-manager.h
       - path: temperature-control-server.h
       - path: TemperatureControlCluster.h

--- a/slc/component/matter-clusters/matter_temperature_control.slcc
+++ b/slc/component/matter-clusters/matter_temperature_control.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_temperature_control
 source:
   - path: third_party/matter_sdk/src/app/clusters/temperature-control-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/temperature-control-server/TemperatureControlCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/temperature-control-server

--- a/slc/component/matter-clusters/matter_temperature_control.slcc
+++ b/slc/component/matter-clusters/matter_temperature_control.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_temperature_control
 source:
   - path: third_party/matter_sdk/src/app/clusters/temperature-control-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/temperature-control-server/TemperatureControlCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/temperature-control-server

--- a/slc/component/matter-clusters/matter_temperature_measurement.slcc
+++ b/slc/component/matter-clusters/matter_temperature_measurement.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_temperature_measurement
 source:
   - path: third_party/matter_sdk/src/app/clusters/temperature-measurement-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/temperature-measurement-server/TemperatureMeasurementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/temperature-measurement-server

--- a/slc/component/matter-clusters/matter_temperature_measurement.slcc
+++ b/slc/component/matter-clusters/matter_temperature_measurement.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_temperature_measurement
 source:
   - path: third_party/matter_sdk/src/app/clusters/temperature-measurement-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/temperature-measurement-server/TemperatureMeasurementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/temperature-measurement-server

--- a/slc/component/matter-clusters/matter_temperature_measurement.slcc
+++ b/slc/component/matter-clusters/matter_temperature_measurement.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/temperature-measurement-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: TemperatureMeasurementCluster.h
 template_contribution:
   - name: component_catalog

--- a/slc/component/matter-clusters/matter_thread_network_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_thread_network_diagnostics.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_thread_network_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/thread-network-diagnostics-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsProvider.cpp
 include:

--- a/slc/component/matter-clusters/matter_thread_network_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_thread_network_diagnostics.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_thread_network_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/thread-network-diagnostics-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsCluster.cpp
   - path: third_party/matter_sdk/src/app/clusters/thread-network-diagnostics-server/ThreadNetworkDiagnosticsProvider.cpp
 include:

--- a/slc/component/matter-clusters/matter_time_format_localization.slcc
+++ b/slc/component/matter-clusters/matter_time_format_localization.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_time_format_localization
 source:
   - path: third_party/matter_sdk/src/app/clusters/time-format-localization-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/time-format-localization-server/TimeFormatLocalizationCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/time-format-localization-server

--- a/slc/component/matter-clusters/matter_time_format_localization.slcc
+++ b/slc/component/matter-clusters/matter_time_format_localization.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_time_format_localization
 source:
   - path: third_party/matter_sdk/src/app/clusters/time-format-localization-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/time-format-localization-server/TimeFormatLocalizationCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/time-format-localization-server

--- a/slc/component/matter-clusters/matter_time_synchronization.slcc
+++ b/slc/component/matter-clusters/matter_time_synchronization.slcc
@@ -30,3 +30,6 @@ include:
 template_contribution:
   - name: component_catalog
     value: matter_time_synchronization
+define:
+  - name: TIME_SYNC_ENABLE_TSC_FEATURE
+    value: 1    

--- a/slc/component/matter-clusters/matter_time_synchronization.slcc
+++ b/slc/component/matter-clusters/matter_time_synchronization.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_time_synchronization
 source:
   - path: third_party/matter_sdk/src/app/clusters/time-synchronization-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/time-synchronization-server/DefaultTimeSyncDelegate.cpp
   - path: third_party/matter_sdk/src/app/clusters/time-synchronization-server/TimeSyncDataProvider.cpp
   - path: third_party/matter_sdk/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp

--- a/slc/component/matter-clusters/matter_time_synchronization.slcc
+++ b/slc/component/matter-clusters/matter_time_synchronization.slcc
@@ -21,6 +21,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/time-synchronization-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: DefaultTimeSyncDelegate.h
       - path: time-synchronization-delegate.h
       - path: time-synchronization-server.h
@@ -29,6 +30,3 @@ include:
 template_contribution:
   - name: component_catalog
     value: matter_time_synchronization
-define:
-  - name: TIME_SYNC_ENABLE_TSC_FEATURE
-    value: 1

--- a/slc/component/matter-clusters/matter_time_synchronization.slcc
+++ b/slc/component/matter-clusters/matter_time_synchronization.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_time_synchronization
 source:
   - path: third_party/matter_sdk/src/app/clusters/time-synchronization-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/time-synchronization-server/DefaultTimeSyncDelegate.cpp
   - path: third_party/matter_sdk/src/app/clusters/time-synchronization-server/TimeSyncDataProvider.cpp
   - path: third_party/matter_sdk/src/app/clusters/time-synchronization-server/TimeSynchronizationCluster.cpp

--- a/slc/component/matter-clusters/matter_tls_certificate_management.slcc
+++ b/slc/component/matter-clusters/matter_tls_certificate_management.slcc
@@ -14,7 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
   - path: third_party/matter_sdk/src/app/clusters/tls-certificate-management-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/tls-certificate-management-server/TLSCertificateManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/tls-certificate-management-server

--- a/slc/component/matter-clusters/matter_tls_certificate_management.slcc
+++ b/slc/component/matter-clusters/matter_tls_certificate_management.slcc
@@ -22,6 +22,7 @@ include:
       - path: CertificateTable.h
       - path: CertificateTableImpl.h
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: IncrementingIdHelper.h
       - path: TLSCertificateManagementCluster.h
 template_contribution:

--- a/slc/component/matter-clusters/matter_tls_certificate_management.slcc
+++ b/slc/component/matter-clusters/matter_tls_certificate_management.slcc
@@ -14,6 +14,7 @@ provides:
 source:
   - path: third_party/matter_sdk/src/app/clusters/tls-certificate-management-server/CertificateTableImpl.cpp
   - path: third_party/matter_sdk/src/app/clusters/tls-certificate-management-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/tls-certificate-management-server/TLSCertificateManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/tls-certificate-management-server

--- a/slc/component/matter-clusters/matter_tls_management_server_client.slcc
+++ b/slc/component/matter-clusters/matter_tls_management_server_client.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/tls-client-management-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: TLSClientManagementCluster.h
 template_contribution:
   - name: component_catalog

--- a/slc/component/matter-clusters/matter_tls_management_server_client.slcc
+++ b/slc/component/matter-clusters/matter_tls_management_server_client.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_tls_management_server_client
 source:
   - path: third_party/matter_sdk/src/app/clusters/tls-client-management-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/tls-client-management-server/TLSClientManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/tls-client-management-server

--- a/slc/component/matter-clusters/matter_tls_management_server_client.slcc
+++ b/slc/component/matter-clusters/matter_tls_management_server_client.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_tls_management_server_client
 source:
   - path: third_party/matter_sdk/src/app/clusters/tls-client-management-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/tls-client-management-server/TLSClientManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/tls-client-management-server

--- a/slc/component/matter-clusters/matter_unit_localization.slcc
+++ b/slc/component/matter-clusters/matter_unit_localization.slcc
@@ -20,6 +20,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/unit-localization-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: MigrateUnitLocalizationServerStorage.h
       - path: unit-localization-server.h
       - path: UnitLocalizationCluster.h

--- a/slc/component/matter-clusters/matter_unit_localization.slcc
+++ b/slc/component/matter-clusters/matter_unit_localization.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_unit_localization
 source:
   - path: third_party/matter_sdk/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/unit-localization-server/MigrateUnitLocalizationServerStorage.cpp
   - path: third_party/matter_sdk/src/app/clusters/unit-localization-server/UnitLocalizationCluster.cpp
 include:

--- a/slc/component/matter-clusters/matter_unit_localization.slcc
+++ b/slc/component/matter-clusters/matter_unit_localization.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_unit_localization
 source:
   - path: third_party/matter_sdk/src/app/clusters/unit-localization-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/unit-localization-server/MigrateUnitLocalizationServerStorage.cpp
   - path: third_party/matter_sdk/src/app/clusters/unit-localization-server/UnitLocalizationCluster.cpp
 include:

--- a/slc/component/matter-clusters/matter_user_label.slcc
+++ b/slc/component/matter-clusters/matter_user_label.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_user_label
 source:
   - path: third_party/matter_sdk/src/app/clusters/user-label-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/user-label-server/UserLabelCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/user-label-server

--- a/slc/component/matter-clusters/matter_user_label.slcc
+++ b/slc/component/matter-clusters/matter_user_label.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_user_label
 source:
   - path: third_party/matter_sdk/src/app/clusters/user-label-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/user-label-server/UserLabelCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/user-label-server

--- a/slc/component/matter-clusters/matter_valve_configuration_and_control.slcc
+++ b/slc/component/matter-clusters/matter_valve_configuration_and_control.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/valve-configuration-and-control-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: TimeSyncTracker.h
       - path: valve-configuration-and-control-delegate.h
       - path: valve-configuration-and-control-server.h

--- a/slc/component/matter-clusters/matter_valve_configuration_and_control.slcc
+++ b/slc/component/matter-clusters/matter_valve_configuration_and_control.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_valve_configuration_and_control
 source:
   - path: third_party/matter_sdk/src/app/clusters/valve-configuration-and-control-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/valve-configuration-and-control-server

--- a/slc/component/matter-clusters/matter_valve_configuration_and_control.slcc
+++ b/slc/component/matter-clusters/matter_valve_configuration_and_control.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_valve_configuration_and_control
 source:
   - path: third_party/matter_sdk/src/app/clusters/valve-configuration-and-control-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/valve-configuration-and-control-server/ValveConfigurationAndControlCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/valve-configuration-and-control-server

--- a/slc/component/matter-clusters/matter_webrtc_transport_provider.slcc
+++ b/slc/component/matter-clusters/matter_webrtc_transport_provider.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_webrtc_transport_provider
 source:
   - path: third_party/matter_sdk/src/app/clusters/webrtc-transport-provider-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/webrtc-transport-provider-server

--- a/slc/component/matter-clusters/matter_webrtc_transport_provider.slcc
+++ b/slc/component/matter-clusters/matter_webrtc_transport_provider.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_webrtc_transport_provider
 source:
   - path: third_party/matter_sdk/src/app/clusters/webrtc-transport-provider-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/webrtc-transport-provider-server/WebRTCTransportProviderCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/webrtc-transport-provider-server

--- a/slc/component/matter-clusters/matter_wifi_network_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_wifi_network_diagnostics.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_wifi_network_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-diagnostics-server/WiFiNetworkDiagnosticsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-diagnostics-server

--- a/slc/component/matter-clusters/matter_wifi_network_diagnostics.slcc
+++ b/slc/component/matter-clusters/matter_wifi_network_diagnostics.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_wifi_network_diagnostics
 source:
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-diagnostics-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-diagnostics-server/WiFiNetworkDiagnosticsCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-diagnostics-server

--- a/slc/component/matter-clusters/matter_wifi_network_management.slcc
+++ b/slc/component/matter-clusters/matter_wifi_network_management.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_wifi_network_management
 source:
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-management-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-management-server/WiFiNetworkManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-management-server

--- a/slc/component/matter-clusters/matter_wifi_network_management.slcc
+++ b/slc/component/matter-clusters/matter_wifi_network_management.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_wifi_network_management
 source:
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-management-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-management-server/WiFiNetworkManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-management-server

--- a/slc/component/matter-clusters/matter_wifi_network_management.slcc
+++ b/slc/component/matter-clusters/matter_wifi_network_management.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/wifi-network-management-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: wifi-network-management-server.h
       - path: WiFiNetworkManagementCluster.h
 template_contribution:

--- a/slc/component/matter-clusters/matter_zone_management.slcc
+++ b/slc/component/matter-clusters/matter_zone_management.slcc
@@ -13,7 +13,7 @@ provides:
   - name: matter_zone_management
 source:
   - path: third_party/matter_sdk/src/app/clusters/zone-management-server/CodegenIntegration.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
   - path: third_party/matter_sdk/src/app/clusters/zone-management-server/ZoneManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/zone-management-server

--- a/slc/component/matter-clusters/matter_zone_management.slcc
+++ b/slc/component/matter-clusters/matter_zone_management.slcc
@@ -13,6 +13,7 @@ provides:
   - name: matter_zone_management
 source:
   - path: third_party/matter_sdk/src/app/clusters/zone-management-server/CodegenIntegration.cpp
+    unless: [matter_code_driven]
   - path: third_party/matter_sdk/src/app/clusters/zone-management-server/ZoneManagementCluster.cpp
 include:
   - path: third_party/matter_sdk/src/app/clusters/zone-management-server

--- a/slc/component/matter-clusters/matter_zone_management.slcc
+++ b/slc/component/matter-clusters/matter_zone_management.slcc
@@ -19,6 +19,7 @@ include:
   - path: third_party/matter_sdk/src/app/clusters/zone-management-server
     file_list:
       - path: CodegenIntegration.h
+        unless: [matter_code_driven_dm]
       - path: Delegate.h
       - path: TwoDCartesianZoneStorage.h
       - path: zone-geometry.h

--- a/slc/component/matter-core-sdk/app_common.slcc
+++ b/slc/component/matter-core-sdk/app_common.slcc
@@ -58,10 +58,14 @@ metadata:
 source:
 -   path: third_party/matter_sdk/src/app/reporting/reporting.cpp
 -   path: third_party/matter_sdk/src/app/util/DataModelHandler.cpp
+    unless: [matter_code_driven]
 -   path: third_party/matter_sdk/src/app/util/attribute-storage.cpp
+    unless: [matter_code_driven]
 -   path: third_party/matter_sdk/src/app/util/attribute-table.cpp
+    unless: [matter_code_driven]
 -   path: third_party/matter_sdk/src/app/util/generic-callback-stubs.cpp
 -   path: third_party/matter_sdk/src/app/util/privilege-storage.cpp
 -   path: third_party/matter_sdk/src/app/util/util.cpp
+    unless: [matter_code_driven]
 ui_hints:
   visibility: never

--- a/slc/component/matter-core-sdk/app_common.slcc
+++ b/slc/component/matter-core-sdk/app_common.slcc
@@ -58,14 +58,14 @@ metadata:
 source:
 -   path: third_party/matter_sdk/src/app/reporting/reporting.cpp
 -   path: third_party/matter_sdk/src/app/util/DataModelHandler.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 -   path: third_party/matter_sdk/src/app/util/attribute-storage.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 -   path: third_party/matter_sdk/src/app/util/attribute-table.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 -   path: third_party/matter_sdk/src/app/util/generic-callback-stubs.cpp
 -   path: third_party/matter_sdk/src/app/util/privilege-storage.cpp
 -   path: third_party/matter_sdk/src/app/util/util.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 ui_hints:
   visibility: never

--- a/slc/component/matter-core-sdk/app_common.slcc
+++ b/slc/component/matter-core-sdk/app_common.slcc
@@ -64,6 +64,7 @@ source:
 -   path: third_party/matter_sdk/src/app/util/attribute-table.cpp
     unless: [matter_code_driven_dm]
 -   path: third_party/matter_sdk/src/app/util/generic-callback-stubs.cpp
+    unless: [matter_code_driven_dm]
 -   path: third_party/matter_sdk/src/app/util/privilege-storage.cpp
 -   path: third_party/matter_sdk/src/app/util/util.cpp
     unless: [matter_code_driven_dm]

--- a/slc/component/matter-core-sdk/code_driven_data_model_sources.slcc
+++ b/slc/component/matter-core-sdk/code_driven_data_model_sources.slcc
@@ -1,0 +1,29 @@
+category: Matter|Core
+description: Provides code-driven Matter data model provider sources for cluster integration and attribute access.
+id: code_driven_data_model_sources
+include:
+-   path: third_party/matter_sdk/src/data-model-providers/codedriven
+    file_list:
+    -   path: CodeDrivenDataModelProvider.h
+-   path: third_party/matter_sdk/src/data-model-providers/codedriven/endpoint
+    file_list:
+    -   path: EndpointInterface.h
+    -   path: EndpointInterfaceRegistry.h
+    -   path: SpanEndpoint.h
+label: code_driven_data_model_sources
+package: matter
+provides:
+-   name: matter_code_driven_data_model_sources
+quality: production
+metadata:
+  sbom:
+    license: "Apache 2.0"
+source:
+-   path: third_party/matter_sdk/src/data-model-providers/codedriven/CodeDrivenDataModelProvider.cpp
+-   path: third_party/matter_sdk/src/data-model-providers/codedriven/endpoint/SpanEndpoint.cpp
+-   path: third_party/matter_sdk/src/data-model-providers/codedriven/endpoint/EndpointInterfaceRegistry.cpp
+-   path: third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+ui_hints:
+    visibility: never
+conflicts:
+  - name: matter_codegen_data_model_sources

--- a/slc/component/matter-core-sdk/code_driven_data_model_sources.slcc
+++ b/slc/component/matter-core-sdk/code_driven_data_model_sources.slcc
@@ -23,6 +23,13 @@ source:
 -   path: third_party/matter_sdk/src/data-model-providers/codedriven/endpoint/SpanEndpoint.cpp
 -   path: third_party/matter_sdk/src/data-model-providers/codedriven/endpoint/EndpointInterfaceRegistry.cpp
 -   path: third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+-   path: third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+-   path: third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/cluster-enums-check.h
+-   path: third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+-   path: third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/ids/Attributes.h
+-   path: third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/ids/Clusters.h
+-   path: third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/attributes/Accessors.h
+-   path: third_party/matter_sdk/zzz_generated/app-common/app-common/zap-generated/attribute-type.h
 ui_hints:
     visibility: never
 conflicts:

--- a/slc/component/matter-core-sdk/codegen_data_model_sources.slcc
+++ b/slc/component/matter-core-sdk/codegen_data_model_sources.slcc
@@ -26,3 +26,5 @@ source:
 -   path: third_party/matter_sdk/src/data-model-providers/codegen/Instance.cpp
 ui_hints:
     visibility: never
+conflicts:
+  - name: code_driven_data_model_sources

--- a/slc/component/matter-core-sdk/matter_code_driven_dm.slcc
+++ b/slc/component/matter-core-sdk/matter_code_driven_dm.slcc
@@ -17,4 +17,4 @@ template_contribution:
   - name: component_catalog
     value: matter_code_driven_dm
 conflicts:
-  - name: matter_zap_driven_dm
+  - name: matter_codegen_dm

--- a/slc/component/matter-core-sdk/matter_code_driven_dm.slcc
+++ b/slc/component/matter-core-sdk/matter_code_driven_dm.slcc
@@ -1,18 +1,20 @@
-category: Clusters|Config
+category: Matter|Core|Config
 description: >
   Disable the need for the codegen Integration code when using code driven only implementation
-id: matter_code_driven
+id: matter_code_driven_dm
 package: matter
-label: Matter Code Driven
+label: Matter Code Driven DM
 quality: production
 metadata:
   sbom:
     license: "Apache 2.0"
 provides:
-  - name: matter_code_driven
+  - name: matter_code_driven_dm
 define:
   - name: SL_MATTER_USE_CODE_DRIVEN_DATA_MODEL
     value: '1'
 template_contribution:
   - name: component_catalog
-    value: matter_code_driven
+    value: matter_code_driven_dm
+conflicts:
+  - name: matter_zap_driven_dm

--- a/slc/component/matter-core-sdk/matter_zap_driven_dm.slcc
+++ b/slc/component/matter-core-sdk/matter_zap_driven_dm.slcc
@@ -1,7 +1,7 @@
 category: Matter|Core|Config
 description: >
   Disable the need for the codegen Integration code when using ZAP driven only implementation
-id: matter_zap_driven_dm
+id: matter_codegen_dm
 package: matter
 label: Matter ZAP Driven DM
 quality: production
@@ -9,12 +9,12 @@ metadata:
   sbom:
     license: "Apache 2.0"
 provides:
-  - name: matter_zap_driven_dm
+  - name: matter_codegen_dm
 define:
   - name: SL_MATTER_USE_CODE_DRIVEN_DATA_MODEL
     value: '0'
 template_contribution:
   - name: component_catalog
-    value: matter_zap_driven_dm
+    value: matter_codegen_dm
 conflicts:
   - name: matter_code_driven_dm

--- a/slc/component/matter-core-sdk/matter_zap_driven_dm.slcc
+++ b/slc/component/matter-core-sdk/matter_zap_driven_dm.slcc
@@ -1,0 +1,20 @@
+category: Matter|Core|Config
+description: >
+  Disable the need for the codegen Integration code when using ZAP driven only implementation
+id: matter_zap_driven_dm
+package: matter
+label: Matter ZAP Driven DM
+quality: production
+metadata:
+  sbom:
+    license: "Apache 2.0"
+provides:
+  - name: matter_zap_driven_dm
+define:
+  - name: SL_MATTER_USE_CODE_DRIVEN_DATA_MODEL
+    value: '0'
+template_contribution:
+  - name: component_catalog
+    value: matter_zap_driven_dm
+conflicts:
+  - name: matter_code_driven_dm

--- a/slc/component/matter-core-sdk/types.slcc
+++ b/slc/component/matter-core-sdk/types.slcc
@@ -44,5 +44,6 @@ source:
 -   path: third_party/matter_sdk/src/app/util/attribute-metadata.cpp
 -   path: third_party/matter_sdk/src/app/util/ember-strings.cpp
 -   path: third_party/matter_sdk/src/app/util/ember-io-storage.cpp
+    unless: [matter_code_driven]
 ui_hints:
   visibility: never

--- a/slc/component/matter-core-sdk/types.slcc
+++ b/slc/component/matter-core-sdk/types.slcc
@@ -44,6 +44,6 @@ source:
 -   path: third_party/matter_sdk/src/app/util/attribute-metadata.cpp
 -   path: third_party/matter_sdk/src/app/util/ember-strings.cpp
 -   path: third_party/matter_sdk/src/app/util/ember-io-storage.cpp
-    unless: [matter_code_driven]
+    unless: [matter_code_driven_dm]
 ui_hints:
   visibility: never

--- a/slc/component/matter.slcc
+++ b/slc/component/matter.slcc
@@ -115,6 +115,9 @@ requires:
   - name: matter_callbacks
   - name: matter_check_in_message
   - name: matter_codegen_data_model_sources
+    unless: [matter_code_driven]
+  - name: matter_code_driven_data_model_sources
+    condition: [matter_code_driven]  
   - name: matter_data_model
   - name: matter_data_model_provider
   - name: matter_encode_decode
@@ -127,6 +130,7 @@ requires:
   - name: matter_tracing_headers
   # TODO: Remove once Zap issue is fixed
   - name: matter_zap_include
+    unless: [matter_code_driven]
 recommends:
   - id: matter_configuration_over_swo
   - id: matter_ot_mbedtls_override

--- a/slc/component/matter.slcc
+++ b/slc/component/matter.slcc
@@ -115,9 +115,9 @@ requires:
   - name: matter_callbacks
   - name: matter_check_in_message
   - name: matter_codegen_data_model_sources
-    unless: [matter_code_driven]
+    condition: [matter_zap_driven_dm]
   - name: matter_code_driven_data_model_sources
-    condition: [matter_code_driven]  
+    condition: [matter_code_driven_dm]  
   - name: matter_data_model
   - name: matter_data_model_provider
   - name: matter_encode_decode
@@ -130,7 +130,7 @@ requires:
   - name: matter_tracing_headers
   # TODO: Remove once Zap issue is fixed
   - name: matter_zap_include
-    unless: [matter_code_driven]
+    condition: [matter_zap_driven_dm]
 recommends:
   - id: matter_configuration_over_swo
   - id: matter_ot_mbedtls_override

--- a/slc/component/matter.slcc
+++ b/slc/component/matter.slcc
@@ -115,7 +115,7 @@ requires:
   - name: matter_callbacks
   - name: matter_check_in_message
   - name: matter_codegen_data_model_sources
-    condition: [matter_zap_driven_dm]
+    condition: [matter_codegen_dm]
   - name: matter_code_driven_data_model_sources
     condition: [matter_code_driven_dm]  
   - name: matter_data_model
@@ -130,7 +130,7 @@ requires:
   - name: matter_tracing_headers
   # TODO: Remove once Zap issue is fixed
   - name: matter_zap_include
-    condition: [matter_zap_driven_dm]
+    condition: [matter_codegen_dm]
 recommends:
   - id: matter_configuration_over_swo
   - id: matter_ot_mbedtls_override

--- a/slc/script/gen_cluster_components.py
+++ b/slc/script/gen_cluster_components.py
@@ -284,7 +284,10 @@ for clustercomponentname in sorted(cluster_data.keys()):
             path = "  - path: {}".format(src)
             filedata.append(path)
             if os.path.basename(src) == "CodegenIntegration.cpp":
-                filedata.append("    unless: [matter_code_driven]")
+                filedata.append("    unless: [matter_code_driven_dm]")
+            if os.path.basename(src) == "CodegenInstance.cpp":
+                filedata.append("    unless: [matter_code_driven_dm]")
+
 
     if len(includes) > 0:
         filedata.append("include:")

--- a/slc/script/gen_cluster_components.py
+++ b/slc/script/gen_cluster_components.py
@@ -283,6 +283,8 @@ for clustercomponentname in sorted(cluster_data.keys()):
         for src in sorted(source_data,key=str.casefold):
             path = "  - path: {}".format(src)
             filedata.append(path)
+            if os.path.basename(src) == "CodegenIntegration.cpp":
+                filedata.append("    unless: [matter_code_driven]")
 
     if len(includes) > 0:
         filedata.append("include:")

--- a/slc/script/gen_cluster_components.py
+++ b/slc/script/gen_cluster_components.py
@@ -281,6 +281,8 @@ for clustercomponentname in sorted(cluster_data.keys()):
     if len(source_data) > 0:
         filedata.append("source:")
         for src in sorted(source_data,key=str.casefold):
+            if os.path.basename(src) == "GenericFaultTestEventTriggerHandler.cpp":
+                continue
             path = "  - path: {}".format(src)
             filedata.append(path)
             if os.path.basename(src) == "CodegenIntegration.cpp":
@@ -296,8 +298,14 @@ for clustercomponentname in sorted(cluster_data.keys()):
             filedata.append(path)
             filedata.append("    file_list:")
             for header in sorted(include["file_list"],key=str.casefold):
+                if os.path.basename(header) == "GenericFaultTestEventTriggerHandler.h":
+                    continue
                 path = "      - path: {}".format(header)
                 filedata.append(path)
+                if os.path.basename(header) == "CodegenIntegration.h":
+                    filedata.append("        unless: [matter_code_driven_dm]")
+                if os.path.basename(header) == "CodegenInstance.h":
+                    filedata.append("        unless: [matter_code_driven_dm]")
 
     if config_file_data:
         filedata.append("config_file:")


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
Matter-5189 


Since Wake on Matter is completely code driven, SLC components needed to be refactored in order for it to compile. 


To alleviate the burden of reviewers, this is part 1 of 2, the second part being the SLCP needed for the Wake On Matter sample apps.
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Add the necessary components so that one can build a pure code driven sample apps without the need for ZAP.
<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**

Add a code driven component which can toggle the dependencies tree for `codegen` or `code_driven`
<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Samples apps build and run locally