### PR TITLE
Add needed define to enable groupcast cluster code with slc

### DIFF
--- a/slc/component/matter-clusters/matter_groupcast.slcc
+++ b/slc/component/matter-clusters/matter_groupcast.slcc
@@ -22,3 +22,7 @@ include:
 template_contribution:
   - name: component_catalog
     value: matter_groupcast
+define:
+  # This define is temporary until Groupcast is certified.
+  - name: CHIP_CONFIG_ENABLE_GROUPCAST
+    value: 1


### PR DESCRIPTION
<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
n/a

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Groupcast cluster is enabled but code to support it is gated under a define

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Add define to enable groupcast Cluster code when the cluster is used by an app.
This define to enable groupcast is needed until the feature is officially certified. (Post SVE)

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Build and commissioning Lighting-app confirm Groupcast command and attributes are usable.
Build Thermostat app, confirm groupcast cluster and any related code is not part of the build.