### PR TITLE
MATTER-6267: Removed Template Contributions from SLCP files for 917 NCP

### DIFF
--- a/slc/apps/fan-control-app/wifi/fan-control-app-917-ncp.slcp
+++ b/slc/apps/fan-control-app/wifi/fan-control-app-917-ncp.slcp
@@ -142,11 +142,6 @@ configuration:
 toolchain_settings:
   - option: cxx_standard
     value: gnu++17
-template_contribution:
-  - name: memory_ram_start
-    value: 0x20000000
-  - name: memory_ram_size
-    value: 0x42000
 
 readme:
   - path: ./README_WiFi.md

--- a/slc/apps/lock-app/wifi/lock-app-917-ncp.slcp
+++ b/slc/apps/lock-app/wifi/lock-app-917-ncp.slcp
@@ -166,11 +166,6 @@ configuration:
 toolchain_settings:
   - option: cxx_standard
     value: gnu++17
-template_contribution:
-  - name: memory_ram_start
-    value: 0x20000000
-  - name: memory_ram_size
-    value: 0x42000
 
 readme:
   - path: ./README_WiFi.md

--- a/slc/apps/thermostat/wifi/thermostat-917-ncp.slcp
+++ b/slc/apps/thermostat/wifi/thermostat-917-ncp.slcp
@@ -161,11 +161,6 @@ configuration:
 toolchain_settings:
   - option: cxx_standard
     value: gnu++17
-template_contribution:
-  - name: memory_ram_start
-    value: 0x20000000
-  - name: memory_ram_size
-    value: 0x42000
 
 readme:
   - path: ./README_WiFi.md

--- a/slc/apps/window-app/wifi/window-app-917-ncp.slcp
+++ b/slc/apps/window-app/wifi/window-app-917-ncp.slcp
@@ -165,11 +165,6 @@ configuration:
 toolchain_settings:
   - option: cxx_standard
     value: gnu++17
-template_contribution:
-  - name: memory_ram_start
-    value: 0x20000000
-  - name: memory_ram_size
-    value: 0x42000
 
 readme:
   - path: ./README_WiFi.md


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** MATTER-6267

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** Following https://jira.silabs.com/browse/PLATFORM_MTL-12078
The value of 0x42000 is greater than the real RAM size of the MG24 of 256KB (0x40000). This result in an erroneous GCC generated linker script leading to define a memory_manager_heap section whose end of heap is located at 0x200420000 instead of 0x200400000 (real end of RAM of the MG24).

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
- Removed the template contribution from the `.slcp` files for 917 NCP.


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
- Locally tested the binary, HardFault is not coming.