### PR TITLE
Refactor MATTER_AWS to integrate with vanilla LwIP ALTCP stack

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,16 @@
+{
+    "recommendations": [
+        "ms-vscode.cpptools",
+        "ms-python.autopep8",
+        "ms-azuretools.vscode-docker",
+        "esbenp.prettier-vscode",
+        "foxundermoon.shell-format",
+        "redhat.vscode-yaml",
+        "christian-kohler.path-intellisense",
+        "rioj7.command-variable",
+        "augustocdias.tasks-shell-input",
+        "marus25.cortex-debug",
+        "mcu-debug.memory-view",
+        "mcu-debug.rtos-views",
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug",
+      "type": "cortex-debug",
+      "cwd": "${workspaceFolder}",
+      "request": "attach",
+      "servertype": "jlink",
+      "serverpath": "/usr/local/bin/JLinkGDBServer",
+      "armToolchainPath": "/Users/svc_matter/.silabs/slt/installs/conan/p/gcc-af360b79bab9e3/p/bin/",
+      "showDevDebugOutput": "vscode",
+      "runToEntryPoint": "main",
+      "rttConfig": {
+        "enabled": true,
+        "address": "auto",
+        "decoders": [
+          {
+            "port": 0, // In RTT lingo, this is the buffer index (or channel)
+            "type": "console"
+          }
+        ]
+      },
+      // BRD4338A
+      "executable": "${workspaceFolder}/out/brd4338a/lighting-app-siwx-solution/lighting-app-siwx/build/debug/lighting-app-siwx.out",
+      "device": "${input:device}",
+      "serialNumber": ""
+    }
+  ],
+  "inputs": [
+    {
+      "id": "device",
+      "type": "pickString",
+      "description": "pick device",
+      "options": ["SiWG917M111M", "EFR32MG12PXXXF1024"]
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,205 @@
+{
+    "C_Cpp.intelliSenseEngineFallback": "Enabled",
+    "C_Cpp.default.includePath": [
+        "${workspaceFolder}/third_party/matter_sdk/build/default/src/",
+        "${workspaceFolder}/third_party/matter_sdk/build/default/src/**",
+        "${workspaceFolder}/third_party/matter_sdk/build/default/src/include/**",
+        "${workspaceFolder}/third_party/matter_sdk/build/default/src/lib/**",
+        "${workspaceFolder}/third_party/matter_sdk/config/standalone/",
+        "${workspaceFolder}/third_party/matter_sdk/config/standalone/**",
+        "${workspaceFolder}/third_party/matter_sdk/darwin/Framework/CHIP/**",
+        "${workspaceFolder}/third_party/matter_sdk/examples/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/app/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/ble/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/controller/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/credentials/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/crypto/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/darwin/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/include/",
+        "${workspaceFolder}/third_party/matter_sdk/src/include/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/inet/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/lib/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/lwip/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/messaging/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/platform/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/protocols/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/setup_payload/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/system/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/tracing/**",
+        "${workspaceFolder}/third_party/matter_sdk/src/transport/**",
+        "${workspaceFolder}/third_party/nlassert/repo/include/**",
+        "${workspaceFolder}/third_party/nlio/repo/include/**"
+    ],
+    "[cpp]": {
+        "editor.defaultFormatter": "xaver.clang-format"
+    },
+    "[dockerfile]": {
+        "editor.defaultFormatter": "ms-azuretools.vscode-docker"
+    },
+    "[jsonc]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "[shellscript]": {
+        "editor.defaultFormatter": "foxundermoon.shell-format"
+    },
+    "[properties]": {
+        "editor.defaultFormatter": "foxundermoon.shell-format"
+    },
+    "[markdown]": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode"
+    },
+    "files.associations": {
+        ".gitmodules": "ini",
+        "*.mm": "cpp",
+        "iostream": "cpp",
+        "array": "cpp",
+        "atomic": "cpp",
+        "*.tcc": "cpp",
+        "cctype": "cpp",
+        "clocale": "cpp",
+        "cmath": "cpp",
+        "cstdarg": "cpp",
+        "cstddef": "cpp",
+        "cstdint": "cpp",
+        "cstdio": "cpp",
+        "cstdlib": "cpp",
+        "cwchar": "cpp",
+        "cwctype": "cpp",
+        "deque": "cpp",
+        "unordered_map": "cpp",
+        "vector": "cpp",
+        "exception": "cpp",
+        "algorithm": "cpp",
+        "functional": "cpp",
+        "iterator": "cpp",
+        "memory": "cpp",
+        "memory_resource": "cpp",
+        "optional": "cpp",
+        "string": "cpp",
+        "string_view": "cpp",
+        "system_error": "cpp",
+        "tuple": "cpp",
+        "type_traits": "cpp",
+        "utility": "cpp",
+        "fstream": "cpp",
+        "initializer_list": "cpp",
+        "iosfwd": "cpp",
+        "istream": "cpp",
+        "limits": "cpp",
+        "new": "cpp",
+        "ostream": "cpp",
+        "sstream": "cpp",
+        "stdexcept": "cpp",
+        "streambuf": "cpp",
+        "cinttypes": "cpp",
+        "typeinfo": "cpp",
+        "*.ipp": "cpp",
+        "aes.h": "c",
+        "stdio.h": "c",
+        "complex": "cpp",
+        "cstring": "cpp",
+        "ctime": "cpp",
+        "bitset": "cpp",
+        "iomanip": "cpp",
+        "hashtable": "cpp",
+        "__bit_reference": "cpp",
+        "__config": "cpp",
+        "__debug": "cpp",
+        "__errc": "cpp",
+        "__functional_base": "cpp",
+        "__hash_table": "cpp",
+        "__locale": "cpp",
+        "__mutex_base": "cpp",
+        "__node_handle": "cpp",
+        "__nullptr": "cpp",
+        "__split_buffer": "cpp",
+        "__string": "cpp",
+        "__threading_support": "cpp",
+        "__tree": "cpp",
+        "__tuple": "cpp",
+        "bit": "cpp",
+        "chrono": "cpp",
+        "ios": "cpp",
+        "locale": "cpp",
+        "map": "cpp",
+        "mutex": "cpp",
+        "queue": "cpp",
+        "ratio": "cpp",
+        "set": "cpp",
+        "stack": "cpp",
+        "regex": "cpp",
+        "condition_variable": "cpp",
+        "numeric": "cpp",
+        "random": "cpp",
+        "thread": "cpp",
+        "variant": "cpp",
+        "any": "cpp",
+        "future": "cpp",
+        "list": "cpp",
+        "unordered_set": "cpp"
+    },
+    "[ini]": {
+        "editor.formatOnSave": false
+    },
+    // Configure paths or glob patterns to exclude from file watching.
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "out/": true,
+        "**/third_party/**": true
+    },
+    "files.eol": "\n",
+    "editor.formatOnSave": true,
+    "better-comments.tags": [
+        {
+            "tag": "!",
+            "color": "#FF2D00",
+            "strikethrough": false,
+            "backgroundColor": "transparent"
+        },
+        {
+            "tag": "?",
+            "color": "#3498DB",
+            "strikethrough": false,
+            "backgroundColor": "transparent"
+        },
+        {
+            "tag": "//",
+            "color": "#474747",
+            "strikethrough": true,
+            "backgroundColor": "transparent"
+        },
+        {
+            "tag": "todo",
+            "color": "#FF8C00",
+            "strikethrough": false,
+            "backgroundColor": "transparent"
+        },
+        {
+            "tag": "fixme",
+            "color": "#FF8C00",
+            "strikethrough": false,
+            "backgroundColor": "transparent"
+        },
+        {
+            "tag": "*",
+            "color": "#98C379",
+            "strikethrough": false,
+            "backgroundColor": "transparent"
+        }
+    ],
+    "clang-format.fallbackStyle": "WebKit",
+    "files.trimFinalNewlines": true,
+    "C_Cpp.default.cppStandard": "gnu++17",
+    "C_Cpp.default.cStandard": "gnu11",
+    "cmake.configureOnOpen": false,
+    "search.followSymlinks": false,
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.autopep8"
+    },
+    "autopep8.args": [
+        "--max-line-length",
+        "132"
+    ]
+}

--- a/slc/component/matter-wifi/matter_aws.slcc
+++ b/slc/component/matter-wifi/matter_aws.slcc
@@ -12,6 +12,8 @@ metadata:
 
 provides:
   - name: matter_aws
+  - name: netstack_silabs_lwip_apps
+  - name: netstack_silabs_lwip_app_altcp_tls
 
 requires:
   - name: mbedtls_sha1
@@ -24,6 +26,8 @@ requires:
   - name: mbedtls_ecc_secp256r1
   - name: mbedtls_gcm
   - name: mbedtls_debug
+  - name: mbedtls_source
+  - name: netstack_silabs_lwip_core
 
 config_file:
   - path: slc/config/matter_aws/sl_matter_wifi_config.h
@@ -35,7 +39,7 @@ config_file:
 define:
   - name: SL_MATTER_ENABLE_AWS
     value: "1"
-# TODO: Rename USE_AWS to reflect proper namespace/context.
+  # TODO: Rename USE_AWS to reflect proper namespace/context.
   - name: USE_AWS
     value: "1"
   - name: SL_MATTER_AWS_NVM_EMBED_CERT
@@ -59,16 +63,10 @@ include:
       - path: mqtt_opts.h
   - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/include
     file_list:
-      - path: altcp.h
-      - path: altcp_opt.h
-      - path: altcp_priv.h
-      - path: altcp_tcp.h
-      - path: altcp_tls.h
       - path: altcp_tls_mbedtls_mem.h
       - path: altcp_tls_mbedtls_opts.h
       - path: altcp_tls_mbedtls_structs.h
       - path: MQTT_transport.h
-      - path: tcpbase.h
 
 template_contribution:
   - name: mbedtls_ssl_content_len_in_requirement
@@ -81,13 +79,10 @@ source:
   - path: third_party/matter_sdk/examples/platform/silabs/matter_aws/matter_aws_interface/src/MatterAwsControl.cpp
   - path: third_party/matter_sdk/examples/platform/silabs/matter_aws/matter_aws_interface/src/MatterAwsNvmCert.cpp
   - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/src/MQTT_transport.c
-  - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp.c
-  - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_alloc.c
-  - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tcp.c
   - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls.c
   - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls_mem.c
   - path: third_party/matter_sdk/src/platform/silabs/mqtt/stack/mqtt.c
 
 toolchain_settings:
-- option: gcc_compiler_option
-  value: -Wno-unused-variable
+  - option: gcc_compiler_option
+    value: -Wno-unused-variable

--- a/slc/component/matter-wifi/matter_aws.slcc
+++ b/slc/component/matter-wifi/matter_aws.slcc
@@ -12,8 +12,6 @@ metadata:
 
 provides:
   - name: matter_aws
-  - name: netstack_silabs_lwip_apps
-  - name: netstack_silabs_lwip_app_altcp_tls
 
 requires:
   - name: mbedtls_sha1
@@ -28,6 +26,8 @@ requires:
   - name: mbedtls_debug
   - name: mbedtls_source
   - name: netstack_silabs_lwip_core
+  - name: netstack_silabs_lwip_app_altcp_tls
+  - name: netstack_silabs_lwip_app_mqtt
 
 config_file:
   - path: slc/config/matter_aws/sl_matter_wifi_config.h
@@ -38,9 +38,6 @@ config_file:
 
 define:
   - name: SL_MATTER_ENABLE_AWS
-    value: "1"
-  # TODO: Rename USE_AWS to reflect proper namespace/context.
-  - name: USE_AWS
     value: "1"
   - name: SL_MATTER_AWS_NVM_EMBED_CERT
     value: "0"
@@ -57,16 +54,6 @@ include:
       - path: MatterAwsConfig.h
       - path: MatterAwsControl.h
       - path: MatterAwsNvmCert.h
-  - path: third_party/matter_sdk/src/platform/silabs/mqtt/stack
-    file_list:
-      - path: mqtt.h
-      - path: mqtt_opts.h
-  - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/include
-    file_list:
-      - path: altcp_tls_mbedtls_mem.h
-      - path: altcp_tls_mbedtls_opts.h
-      - path: altcp_tls_mbedtls_structs.h
-      - path: MQTT_transport.h
 
 template_contribution:
   - name: mbedtls_ssl_content_len_in_requirement
@@ -78,10 +65,6 @@ source:
   - path: third_party/matter_sdk/examples/platform/silabs/matter_aws/matter_aws_interface/src/MatterAws.cpp
   - path: third_party/matter_sdk/examples/platform/silabs/matter_aws/matter_aws_interface/src/MatterAwsControl.cpp
   - path: third_party/matter_sdk/examples/platform/silabs/matter_aws/matter_aws_interface/src/MatterAwsNvmCert.cpp
-  - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/src/MQTT_transport.c
-  - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls.c
-  - path: third_party/matter_sdk/src/platform/silabs/mqtt/mqtt_transport_interface/src/altcp_tls_mbedtls_mem.c
-  - path: third_party/matter_sdk/src/platform/silabs/mqtt/stack/mqtt.c
 
 toolchain_settings:
   - option: gcc_compiler_option


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** MATTER-6156

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** When enabling `LWIP_ALTCP` via LwIP stack, the customer was facing duplicate 
definition error for the functions and source.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:** Remove all the LwIP ALTCP layer from MATTER layer, along with MQTT service. Use LwIP ALTCP layer and LwIP MQTT service.


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:** TBD

- [ ] Requires https://github.com/SiliconLabsSoftware/matter_sdk/pull/926