### PR TITLE
NOJIRA: Re-enable LTO builds for SiWx917 and Series 3 Zigbee lighting

### DIFF
--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -34,6 +34,12 @@
                 "arguments": ["--output_suffix copy-sources", "--copy-sources"]
             }
         ],
+        "lighting_app": [
+            {
+                "boards": ["brd4338a"],
+                "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
+            }
+        ],
         "platform_template": [
             {
                 "boards": ["brd4338a", "brd4343a", "brd4342a"],
@@ -67,6 +73,16 @@
                 "arguments": ["--output_suffix m-ota-enc",
                               "--without_app matter_ota_support",
                               "--with_app matter_multi_image_ota,matter_multi_image_ota_encryption,matter_multi_image_custom_processor"]
+            },
+            {
+                "boards": ["brd4338a", "brd4342a", "brd4343a"],
+                "arguments": ["--output_suffix lto",
+                              "--with_app toolchain_gcc_lto"]
+            },
+            {
+                "boards": ["brd4338a", "brd4342a"],
+                "arguments": ["--output_suffix lto-ota-2", "--with_app toolchain_gcc_lto",
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ],
         "lock_app" :[
@@ -74,6 +90,11 @@
                 "boards": ["brd4338a", "brd4342a", "brd4343a"],
                 "arguments": ["--output_suffix ota-2",
                               "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
+            },
+            {
+                "boards": ["brd4338a", "brd4342a", "brd4343a"],
+                "arguments": ["--output_suffix lto",
+                              "--with_app toolchain_gcc_lto"]
             },
             {
                 "boards": ["brd4338a"],

--- a/.github/silabs-builds-sixg301.json
+++ b/.github/silabs-builds-sixg301.json
@@ -58,6 +58,10 @@
             {
                 "boards": ["brd1019a,SIMG301M113WIH"],
                 "arguments": ["--output_suffix sequential-copy-sources","--with_app matter_zigbee_sequential", "--copy-sources"] 
+            },
+            {
+                "boards": ["brd4407a"],
+                "arguments": ["--output_suffix lto", "--with_app matter_no_debug,toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd", "-pids application"]
             }
         ],
         "thermostat": [


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** LTO builds were failing with GCC toolchain upgrade of 14.2.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:** Adds fix for GCC 14.2 toolchain and revert https://github.com/SiliconLabsSoftware/matter_extension/pull/641


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:** CICD testing of build failure, local sanity testing of EFR32 series 2 and SiWx917.

- [x] https://github.com/SiliconLabsSoftware/matter_sdk/pull/933, depends on this PR (preferred)
- [x] https://github.com/project-chip/connectedhomeip/pull/71785, cherry-pick this PR and rebase matter_sdk (optional)