### PR TITLE
Install gcc from ga server

### DIFF
--- a/.github/actions/install-tools/action.yaml
+++ b/.github/actions/install-tools/action.yaml
@@ -80,7 +80,6 @@ runs:
     - name: install gcc-arm-none-eabi
       shell: bash
       run: |
-        conan remote add silabs-conan-prerelease https://conan-prerelease.silabs.net
         slt install gcc-arm-none-eabi/14.2.rel1
         ARM_GCC_DIR=$(slt where gcc-arm-none-eabi)
         echo "ARM_GCC_DIR=$ARM_GCC_DIR" >> $GITHUB_ENV

--- a/slc/sl_setup_env.py
+++ b/slc/sl_setup_env.py
@@ -239,7 +239,7 @@ class MatterEnvSetup:
                 logging.error(f"Tool path for {tool} is invalid or does not exist: {path}")
                 sys.exit(1)
 
-        arm_gcc_bin = os.path.join(self.paths.get('gcc-arm-none-eabi'), "bin")
+        arm_gcc_bin = os.path.join(self.paths.get('gcc-arm-none-eabi/14.2.rel1'), "bin")
         path_separator = ";" if self.platform == "win32" else ":"
 
         if self.platform == "darwin":
@@ -337,7 +337,7 @@ class MatterEnvSetup:
     
     def setup_tools(self):
         """Install and configure all required development tools."""
-        tools_list = ["slc-cli", "java21", "gcc-arm-none-eabi", "commander", "ninja", "cmake"]
+        tools_list = ["slc-cli", "java21", "gcc-arm-none-eabi/14.2.rel1", "commander", "ninja", "cmake"]
         self.paths = {}
         for tool in tools_list:
             self.paths[tool] = self.install_tools(tool)

--- a/slc/sl_setup_env.py
+++ b/slc/sl_setup_env.py
@@ -265,7 +265,7 @@ class MatterEnvSetup:
         try:
             with open(env_path, "w") as outfile:
                 outfile.write(f"STUDIO_ADAPTER_PACK_PATH={self.zap_path}\n")
-                outfile.write(f"ARM_GCC_DIR={self.paths.get('gcc-arm-none-eabi')}\n")
+                outfile.write(f"ARM_GCC_DIR={self.paths.get('gcc-arm-none-eabi/14.2.rel1')}\n")
                 outfile.write(f"JAVA_HOME={java_path}\n")
                 outfile.write(f"ZAP_INSTALL_PATH={self.zap_path}\n")
                 outfile.write(


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Locally ran and verified the correct version of gcc.
Ran create and build 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because the toolchain key/name is changed to a version-pinned identifier, which can break environment setup if other steps still expect the unversioned `gcc-arm-none-eabi` path/variable.
> 
> **Overview**
> Pins the ARM GCC toolchain installation to `gcc-arm-none-eabi/14.2.rel1` in both the GitHub composite action and `slc/sl_setup_env.py`, removing the previous Conan prerelease remote addition.
> 
> The local setup script now installs and builds `TOOLS_PATH` using the versioned tool key, which changes how the GCC bin directory is resolved during environment generation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fc1d4162b9eb37a6d1b4851388970e48c167897. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->