### PR TITLE
[MATTER-6313] Add the missing Performance Testing Cluster

### DIFF
--- a/slc/apps/performance_test_app/thread/performance-test-app.zap
+++ b/slc/apps/performance_test_app/thread/performance-test-app.zap
@@ -3807,6 +3807,122 @@
               "included": 1
             }
           ]
+        },
+        {
+          "name": "Performance Testing",
+          "code": 4294048834,
+          "mfgCode": null,
+          "define": "PERFORMANCE_TESTING_CLUSTER",
+          "side": "server",
+          "enabled": 1,
+          "commands": [
+            {
+              "name": "EmptyCommand",
+              "code": 0,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            }
+          ],
+          "attributes": [
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "FeatureMap",
+              "code": 65532,
+              "mfgCode": null,
+              "side": "server",
+              "type": "bitmap32",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ClusterRevision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
https://jira.silabs.com/browse/MATTER-6313
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
The ZAP file update in https://github.com/SiliconLabsSoftware/matter_extension/pull/675 accidentally left out the Performance Testing Cluster

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Add the missing Performance Testing Cluster to the performance-test-app ZAP file

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Verified the "perf ping command" is executed on the device

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk ZAP configuration update that only affects generated Matter cluster/command metadata for the performance test app; behavior changes should be limited to enabling the missing cluster/command exposure.
> 
> **Overview**
> Restores the missing **Performance Testing** cluster definition in `performance-test-app.zap`, including its `EmptyCommand` and required descriptor attributes (`GeneratedCommandList`, `AcceptedCommandList`, `EventList`, `AttributeList`, `FeatureMap`, `ClusterRevision`).
> 
> Also fixes the file to end with a newline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 701421a49dd5702fa0fd3d8fa71be6274fe820ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->