### PR TITLE
Update get_workflow_info to retrieve workflows using branch name as filter

### DIFF
--- a/jenkins_integration/config.py
+++ b/jenkins_integration/config.py
@@ -5,8 +5,6 @@ repo_name = "matter_extension"
 pr_sha_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/pulls'
 sha_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/commits?sha='
 commits_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/commits'
-actions_runs_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?per_page=100'
-actions_runs_url_pr = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs?event=pull_request&per_page=100'
 actions_runs_base_url = f'https://api.github.com/repos/{repo_owner}/{repo_name}/actions/runs'
 github_auth = "Bearer " + os.environ["GITHUB_ACCESS_TOKEN"]
 github_headers = {

--- a/jenkins_integration/github/github_workflow.py
+++ b/jenkins_integration/github/github_workflow.py
@@ -12,6 +12,7 @@ import requests
 import time
 import os
 import sys
+from urllib.parse import quote
 
 # Add the workspace root to Python path to enable importing internal modules
 workspace_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -68,18 +69,22 @@ def get_workflow_info(branch_name):
     """
     if branch_name.startswith("PR"):
         head_branch = _get_pr_latest_sha(branch_name)
+        pr_base = f"{config.actions_runs_base_url}?event=pull_request&per_page=100"
         if head_branch:
-            pr_url = f"{config.actions_runs_url_pr}&branch={head_branch}"
+            pr_url = f"{pr_base}&branch={quote(head_branch, safe='')}"
         else:
-            pr_url = config.actions_runs_url_pr
+            pr_url = pr_base
         print(f"Fetching workflow runs from actions/runs event Pull Request URL: {pr_url}")
         response = _make_github_api_request(pr_url)
         workflow_runs = response.json().get('workflow_runs', [])
         pr_number = branch_name.split('-')[1]
         return _find_pr_workflow(workflow_runs, pr_number)
     else:
-        print(f"Fetching workflow runs from actions/runs URL: {config.actions_runs_url}")
-        response = _make_github_api_request(config.actions_runs_url)
+        branch_runs_url = (
+            f"{config.actions_runs_base_url}?per_page=100&branch={quote(branch_name, safe='')}"
+        )
+        print(f"Fetching workflow runs for branch from URL: {branch_runs_url}")
+        response = _make_github_api_request(branch_runs_url)
         workflow_runs = response.json().get('workflow_runs', [])
         return _find_branch_workflow(workflow_runs, branch_name)
 
@@ -390,7 +395,6 @@ def _handle_test_timeout():
     """
     print("Waiting for test results timed out for the latest workflow run. "
           "Jenkins job running on completed workflow. Bypass sending test results to GitHub.")
-
 
 def _is_artifact_job_complete(check_run):
     """


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
When a workflow fails and we re-trigger it, it may fail to retrieve workflow info as seen here because other jobs ran and the re-triggered job is not present on the first page. 
 https://jenkins-cbs-iot-matter.silabs.net/blue/organizations/jenkins/Matter%20Extension%20GitHub/detail/release_2.9-1.6/11/pipeline/

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Filter by the branch name so that the workflow can be found even if a certain amount of other workflows ran. 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Ran as branch https://jenkins-cbs-iot-matter.silabs.net/job/Matter%20Extension%20GitHub/job/fix_get_workflow_info/2/ and ran as PR.