### PR TITLE
NOJIRA: Update slcp validation script

### DIFF
--- a/slc/script/validate_app_standardization.py
+++ b/slc/script/validate_app_standardization.py
@@ -48,7 +48,10 @@ _NCP_README_HINT = re.compile(
 
 _APP_NAME_RE = re.compile(r"^[a-z][a-z0-9_]*$")
 
-_DESCRIPTION_SAMPLE_PREFIX = "Demonstrates a sample implementation of "
+_DESCRIPTION_ALLOWED_PREFIXES: Tuple[str, ...] = (
+    "Demonstrates a sample implementation of ",
+    "Demonstrates a POC of ",
+)
 @dataclass(frozen=True)
 class _LabelClaimRequiresProjectName:
     """If label matches label_pattern, project_name must satisfy name_ok"""
@@ -433,10 +436,12 @@ def _validate_common_studio_fields(
         skip_desc_shape = _is_bootloaderish(rel_posix, app_name_for_taxonomy) or (
             "/openthread_border_router_doc/" in rp
         )
-        if not skip_desc_shape and not desc.startswith(_DESCRIPTION_SAMPLE_PREFIX):
+        if not skip_desc_shape and not any(
+            desc.startswith(p) for p in _DESCRIPTION_ALLOWED_PREFIXES
+        ):
             rep.add(
-                "description must start with \"Demonstrates a sample implementation of ...\" "
-                "(SiSDK pattern for Matter apps)"
+                "description must start with \"Demonstrates a sample implementation of ...\" (production quality apps) "
+                'or "Demonstrates a POC of ..." (non-production quality apps)'
             )
 
 def validate_slcp(path: Path, rel_posix: str) -> FileReport:


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Not all apps (such as wake on matter) are of production quality, and therefore description suffix being "Demonstrates a sample implementation of ..." can be misleading in terms of the quality of the app.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Add "Demonstrates a POC of ..." as allowable description suffix in validation script 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Test script locally 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a lint/validation rule for `.slcp/.slcw` metadata descriptions, with no runtime product impact.
> 
> **Overview**
> Relaxes `slc/script/validate_app_standardization.py` description validation to allow two accepted prefixes instead of only requiring `"Demonstrates a sample implementation of ..."`.
> 
> Descriptions may now also start with `"Demonstrates a POC of ..."`, and the validation error message is updated to reflect the production vs non-production wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2af1bf1a17f22ed27378a9cceab8443aa8e9e112. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->