### PR TITLE
Refactor sdk-submodule-bump workflow inputs and logic

### DIFF
--- a/.github/workflows/sdk-submodule-bump.yaml
+++ b/.github/workflows/sdk-submodule-bump.yaml
@@ -11,8 +11,8 @@ on:
         options:
           - 2025.12
           - 2026.6
-      sisdk-build-number:
-        description: 'SDK (sisdk-prerelease and wiseconnect-prerelease) Build Number to bump to (e.g., 1355)'
+      sisdk-tag:
+        description: 'SDK (sisdk-prerelease and wiseconnect-prerelease) Build Number to bump to (e.g., v2026.6-build.sisdk-2026.6-558 or v2025.12-build.2710)'
         required: true
         type: string
 
@@ -26,14 +26,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          SISDK_VERSION="${{ inputs.sisdk-version }}"
-          SISDK_BUILD_NUMBER="${{ inputs.sisdk-build-number }}"
-
-          # Input validation - ensure build number contains only digits
-          if [[ ! "$SISDK_BUILD_NUMBER" =~ ^[0-9]+$ ]]; then
-            echo "Error: Build number must contain only digits. Received: $SISDK_BUILD_NUMBER"
-            exit 1
-          fi
+          SISDK_VERSION="${{ inputs.sisdk-tag }}"
+          SDK_TAG="${{ inputs.sisdk-tag }}"
 
           case "$SISDK_VERSION" in
             "2025.12")
@@ -43,20 +37,17 @@ jobs:
               TARGET_BRANCH="release_2.9-1.6"
               ;;
           esac
-
-          SDK_TAG="v${SISDK_VERSION}-build.${SISDK_BUILD_NUMBER}"
+          
           PR_BRANCH="automation/update_sdk_submodules_${SISDK_VERSION//./_}_${SISDK_BUILD_NUMBER}"
 
           echo "sisdk_version=$SISDK_VERSION" >> "$GITHUB_OUTPUT"
-          echo "sisdk_build_number=$SISDK_BUILD_NUMBER" >> "$GITHUB_OUTPUT"
           echo "sdk_tag=$SDK_TAG" >> "$GITHUB_OUTPUT"
           echo "pr_branch=$PR_BRANCH" >> "$GITHUB_OUTPUT"
           echo "target_branch=$TARGET_BRANCH" >> "$GITHUB_OUTPUT"
 
           echo "Selected SiSDK version: $SISDK_VERSION"
-          echo "Selected build number: $SISDK_BUILD_NUMBER"
+          echo "Selected SDK tag: $SDK_TAG"
           echo "Resolved target branch: $TARGET_BRANCH"
-          echo "Resolved SDK tag: $SDK_TAG"
           echo "Resolved PR branch: $PR_BRANCH"
 
       - name: Checkout repository
@@ -76,12 +67,10 @@ jobs:
         run: |
           set -euo pipefail          
           SISDK_VERSION="${{ steps.resolve_inputs.outputs.sisdk_version }}"
-          SISDK_BUILD_NUMBER="${{ steps.resolve_inputs.outputs.sisdk_build_number }}"
           SDK_TAG="${{ steps.resolve_inputs.outputs.sdk_tag }}"
 
           echo "Bumping simplicity_sdk and wifi_sdk"
           echo "SiSDK version: $SISDK_VERSION"
-          echo "Build number: $SISDK_BUILD_NUMBER"
           echo "Tag: $SDK_TAG"
 
           git submodule update --init third_party/simplicity_sdk

--- a/.github/workflows/sdk-submodule-bump.yaml
+++ b/.github/workflows/sdk-submodule-bump.yaml
@@ -9,10 +9,10 @@ on:
         type: choice
         default: '2026.6'
         options:
-          - 2025.12
-          - 2026.6
+          - '2025.12'
+          - '2026.6'
       sisdk-tag:
-        description: 'SDK (sisdk-prerelease and wiseconnect-prerelease) Build Number to bump to (e.g., v2026.6-build.sisdk-2026.6-558 or v2025.12-build.2710)'
+        description: 'SDK (sisdk-prerelease and wiseconnect-prerelease) tag to bump to (e.g., v2026.6-build.sisdk-2026.6-558 or v2025.12-build.2710)'
         required: true
         type: string
 
@@ -26,7 +26,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          SISDK_VERSION="${{ inputs.sisdk-tag }}"
+          SISDK_VERSION="${{ inputs.sisdk-version }}"
           SDK_TAG="${{ inputs.sisdk-tag }}"
 
           case "$SISDK_VERSION" in
@@ -37,8 +37,8 @@ jobs:
               TARGET_BRANCH="release_2.9-1.6"
               ;;
           esac
-          
-          PR_BRANCH="automation/update_sdk_submodules_${SISDK_VERSION//./_}_${SISDK_BUILD_NUMBER}"
+
+          PR_BRANCH="automation/update_sdk_submodules_${SDK_TAG}"
 
           echo "sisdk_version=$SISDK_VERSION" >> "$GITHUB_OUTPUT"
           echo "sdk_tag=$SDK_TAG" >> "$GITHUB_OUTPUT"
@@ -56,16 +56,16 @@ jobs:
           submodules: false
           ref: ${{ steps.resolve_inputs.outputs.target_branch }}
           persist-credentials: false
-      
+
       - name: Mark repository as safe for Git
         shell: bash
         run: |
-          git config --global --add safe.directory /__w/matter_extension/matter_extension
-      
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Bump SDK submodules
         shell: bash
         run: |
-          set -euo pipefail          
+          set -euo pipefail
           SISDK_VERSION="${{ steps.resolve_inputs.outputs.sisdk_version }}"
           SDK_TAG="${{ steps.resolve_inputs.outputs.sdk_tag }}"
 
@@ -75,24 +75,31 @@ jobs:
 
           git submodule update --init third_party/simplicity_sdk
           git submodule update --init third_party/wifi_sdk
-          cd third_party/simplicity_sdk
-          git fetch origin
-          git checkout "$SDK_TAG"
 
-          cd ../wifi_sdk
-          git fetch origin
-          git checkout "$SDK_TAG"
-          cd ../..
+          (
+            cd third_party/simplicity_sdk
+            git fetch --tags origin
+            git checkout "$SDK_TAG"
+          )
+
+          (
+            cd third_party/wifi_sdk
+            git fetch --tags origin
+            git checkout "$SDK_TAG"
+          )
 
           echo "Updating .gitmodules tags..."
-          # Update the tags in .gitmodules
-          sed -i -E "s#^([[:space:]]*tag = )(v2025\.12|v2026\.6)-build\.[0-9]*\$#\1${SDK_TAG}#g" .gitmodules
-          # Display the updated .gitmodules content
+          # Escape dots in the version for the regex, then replace any tag of the
+          # form vSISDK_VERSION-build.<anything> with the new SDK_TAG. This handles
+          # both "v2025.12-build.2710" and "v2026.6-build.sisdk-2026.6-558" formats.
+          SISDK_VERSION_ESCAPED="${SISDK_VERSION//./\\.}"
+          sed -i -E "s#^([[:space:]]*tag = )v${SISDK_VERSION_ESCAPED}-build\\..*\$#\\1${SDK_TAG}#g" .gitmodules
+
           echo "Updated .gitmodules:"
           cat .gitmodules
 
           git add third_party/simplicity_sdk third_party/wifi_sdk .gitmodules
-              
+
       - name: Generate token for the workflow
         id: generate_token
         uses: actions/create-github-app-token@v3
@@ -103,18 +110,17 @@ jobs:
 
       - name: Mask the generated token
         run: echo "::add-mask::${{ steps.generate_token.outputs.token }}"
-      
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
           branch: ${{ steps.resolve_inputs.outputs.pr_branch }}
           base: ${{ steps.resolve_inputs.outputs.target_branch }}
           title: "Update SDK submodules to ${{ steps.resolve_inputs.outputs.sdk_tag }} on ${{ steps.resolve_inputs.outputs.target_branch }}"
+          commit-message: "Update SDK submodules to ${{ steps.resolve_inputs.outputs.sdk_tag }}"
           body: |
             This PR updates the simplicity_sdk and wifi_sdk submodules to `${{ steps.resolve_inputs.outputs.sdk_tag }}` on the `${{ steps.resolve_inputs.outputs.target_branch }}` branch.
 
             - SiSDK version: `${{ steps.resolve_inputs.outputs.sisdk_version }}`
-            - Build number: `${{ steps.resolve_inputs.outputs.sisdk_build_number }}`
             - Resolved tag: `${{ steps.resolve_inputs.outputs.sdk_tag }}`
-
           token: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Updated the workflow to use 'sisdk-tag' input instead of 'sisdk-build-number'. Adjusted the SDK tag generation and removed build number validation.

<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to a GitHub Actions workflow, but incorrect tag/regex handling could cause the automation to bump submodules to the wrong ref or fail to update `.gitmodules`.
> 
> **Overview**
> **Refactors the `sdk-submodule-bump` workflow to take an explicit `sisdk-tag` input** instead of a numeric build number, removing build-number validation and tag construction.
> 
> Updates the bump logic to `fetch --tags` and checkout the provided tag for both SDK submodules, adjusts PR branch naming/PR commit message, and broadens the `.gitmodules` `sed` replacement to handle multiple tag formats for a given SiSDK version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0519dcde7a7b554004da18aff1fa2489137f801b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->