### PR TITLE
[SL-UP] NOJIRA: Remove unused `toolchain_gcc_common` dependency from SiWx EVSE application

### DIFF
--- a/slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcp
+++ b/slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcp
@@ -82,8 +82,6 @@ component:
     from: matter
   - id: matter_ota_support
     from: matter
-  - id: toolchain_gcc_common
-    from: matter
   - id: matter_power_source
     from: matter
   - id: matter_shell


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** NO JIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Compilation fails as the `toolchain_gcc_common` component in `matter` is not updated with WiseConnect 3 linker changes.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Remove `toolchain_gcc_common` component and use the WiseConnect 3 packaged linker file instead. This change was done for all the other combinations but was missed for the EVSE application.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Locally built the application and CICD.