### PR TITLE
MATTER-6333: Adding the required component for multi-ota fix

### DIFF
--- a/slc/component/matter-platform/ota/matter_multi_image_ota_encryption.slcc
+++ b/slc/component/matter-platform/ota/matter_multi_image_ota_encryption.slcc
@@ -15,6 +15,7 @@ provides:
 
 requires:
   - name: matter_multi_image_ota
+  - name: mbedtls_cipher_ctr
 
 source:
   - path: third_party/matter_sdk/src/platform/silabs/multi-ota/OtaTlvEncryptionKeyPSA.cpp


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
MATTER-6333

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Multi-ota binaries are failing to build

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
One of the encryption API, was missing the required mbedtls config
adding mbedtls_cipher_ctr component https://github.com/SiliconLabsSoftware/sisdk-prerelease/blob/sisdk-2026.6/platform_core/platform/security/component/mbedtls_cipher_ctr.slcc
required to compile https://github.com/SiliconLabsSoftware/sisdk-prerelease/blob/sisdk-2026.6/mbedtls/library/aes.c#L1433-L1482

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Local build with the BRD4338A and BRD4187C