### PR TITLE
Revert "Add support for a debug watchdog with extension."

### DIFF
--- a/.github/silabs-builds-sixg301.json
+++ b/.github/silabs-builds-sixg301.json
@@ -3,7 +3,7 @@
         "default": [
             {
                 "boards": ["brd4407a"],
-                "arguments": ["--configuration SL_MATTER_DEBUG_WATCHDOG_ENABLE:1"]
+                "arguments": [""]
             },
             {
                 "boards": ["brd4407a"],
@@ -13,7 +13,7 @@
         "zigbee_light": [
             {
                 "boards": ["brd4407a"],
-                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential", "--configuration SL_MATTER_DEBUG_WATCHDOG_ENABLE:1"] 
+                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential"] 
             },
             {
                 "boards": ["brd4407a"],
@@ -31,7 +31,7 @@
         "default": [
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a", "brd4408a"],
-                "arguments": ["--configuration SL_MATTER_DEBUG_WATCHDOG_ENABLE:1"] 
+                "arguments": [""] 
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH"],
@@ -53,7 +53,7 @@
         "zigbee_light":  [
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a", "brd4408a"],
-                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential", "--configuration SL_MATTER_DEBUG_WATCHDOG_ENABLE:1"] 
+                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential"] 
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH"],
@@ -77,11 +77,11 @@
         "platform_template": [
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a"],
-                "arguments": ["--output_suffix peripherals","--with_app matter_peripherals", "--configuration SL_MATTER_DEBUG_WATCHDOG_ENABLE:1"] 
+                "arguments": ["--output_suffix peripherals","--with_app matter_peripherals"] 
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a"],
-                "arguments": ["--output_suffix peripherals-icd","--with_app matter_peripherals,matter_icd_core", "--configuration SL_MATTER_DEBUG_WATCHDOG_ENABLE:1"] 
+                "arguments": ["--output_suffix peripherals-icd","--with_app matter_peripherals,matter_icd_core"] 
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a"],
@@ -94,53 +94,53 @@
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a"],
                 "arguments": ["--output_suffix ota-2", "-pids application",
-                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a"],
                 "arguments": ["--output_suffix lto",
-                              "--with_app toolchain_gcc_lto", "--configuration SL_MATTER_DEBUG_WATCHDOG_ENABLE:1"]
+                              "--with_app toolchain_gcc_lto"]
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH"],
                 "arguments": ["--output_suffix lto-ota-2", "--with_app toolchain_gcc_lto", "-pids application",
-                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ],
         "lock_app": [
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a"],
                 "arguments": ["--output_suffix ota-2", "-pids application",
-                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a"],
                 "arguments": ["--output_suffix lto",
-                              "--with_app toolchain_gcc_lto", "--configuration SL_MATTER_DEBUG_WATCHDOG_ENABLE:1"]
+                              "--with_app toolchain_gcc_lto"]
             },
             {
                 "boards": ["brd4407a"],
                 "arguments": ["--output_suffix lto-ota-2", "--with_app toolchain_gcc_lto", "-pids application",
-                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ],
         "light_switch_app": [
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a"],
                 "arguments": ["--output_suffix ota-2", "-pids application",
-                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ],
         "zigbee_light":  [
               {
                   "boards": ["brd1019a,SIMG301M113WIH", "brd4407a", "brd4408a"],
                   "arguments": ["--output_suffix sequential-ota-2","--with_app matter_zigbee_sequential", "-pids application",
-                                "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                                "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
               },
               {
                   "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a", "brd4408a"],
                   "arguments": ["--output_suffix cmp-concurrent-ota-2","--with_app matter_zigbee_concurrent", "-pids application",
-                                "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                                "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
               },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],
@@ -203,19 +203,19 @@
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],
                 "arguments": ["--output_suffix ota-2", "-pids application",
-                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ],
         "platform_template": [
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],
                 "arguments": ["--output_suffix peripherals-ota-2","--with_app matter_peripherals", "--without_app matter_log_rtt", "-pids application",
-                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],
                 "arguments": ["--output_suffix peripherals-ota-3","--with_app matter_peripherals", "--without_app matter_log_rtt", "-pids application",
-                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:3,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"3\",SL_MATTER_DEBUG_WATCHDOG_ENABLE:1'"]
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:3,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"3\"'"]
             }
         ]
     }

--- a/slc/component/matter-platform/matter_platform_mg.slcc
+++ b/slc/component/matter-platform/matter_platform_mg.slcc
@@ -59,7 +59,6 @@ requires:
   - name: rail_lib_multiprotocol
   - name: rail_util_pti
   - name: freertos_heap_3
-  - name: hal_wdog
   # components required for series 2
   - name: gpiointerrupt
     condition: [device_series_2]

--- a/slc/config/sl_matter_config.h
+++ b/slc/config/sl_matter_config.h
@@ -58,14 +58,6 @@
 #define SL_MATTER_CLI_ARG_PARSER 1
 #endif
 
-// <q SL_MATTER_DEBUG_WATCHDOG_ENABLE> Enable a Watchdog with debug features for MG devices
-// <i> Default: 0
-// <i> Enables a Watchdog with debug features for only MG devices
-// <i> To enable for SiWG devices, directly add the sl_wdt_manager component to the project
-#ifndef SL_MATTER_DEBUG_WATCHDOG_ENABLE
-#define SL_MATTER_DEBUG_WATCHDOG_ENABLE 0
-#endif
-
 // <o CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES> Define the default number of ip addresses to discover
 // <i> Default: 5
 // <i> Maximum number of IP addresses that can be discovered during device commissioning


### PR DESCRIPTION
This reverts commit 3e38b7796ac7f3e4d942f422bf7c078b4dff1549.

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
https://jira.silabs.com/browse/MATTER-5966

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
We had an application level implementation of the efr32 hardware watchdog.

sl_watchdog_manager is a new driver handling this same hardware driver and allowing users to create software watchdog on top of it to ensure runtime of targeted code sections.


<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Our previous implementation is deprecated and we can enable the sl_watchdog_manager directly by adding `watchdog_manager` component to your project.

We will only enable watchdog_manager on some sqa-builds our sample app with not have it enabled by default.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
This only remove the support of the previous watchdog implementation. CI/ Compilation is enough