### PR TITLE
Adding the component to fix the build of thermostat app

### DIFF
--- a/slc/component/matter-core-sdk/zigbee_debug.slcc
+++ b/slc/component/matter-core-sdk/zigbee_debug.slcc
@@ -13,6 +13,7 @@ requires:
   - name: zigbee_debug_print
   - name: zigbee_zcl_cli
   - name: zigbee_core_cli
+  - name: rail_mux_aux
 provides:
   - name: matter_zigbee_debug
 define:


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Thermostat app fails to build with the latest SiSDK update
https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/25869999996/job/76022549591?pr=712

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Added the component where it is including the rail_miux component was including from.
From the SLC graph 
this was coming through the path

`matter_zigbee_debug -> zigbee_system_common -> rail_mux`

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Tested the build locally