### PR TITLE
Increase Upload SQA Artifacts stage timeout by 1 hour

### DIFF
--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -226,7 +226,7 @@ pipeline
             }
             steps {
                 script {
-                    retry(12) {
+                    retry(15) {
                         withDockerContainer(image: 'artifactory.silabs.net/gsdk-docker-production/gsdk_nomad_containers/gsdk_ubai:latest') {
                             def result = pipelineFunctions.upload_artifacts(sqa=true, commit_sha=commit_sha, workflow_id=workflow_id)
                         }


### PR DESCRIPTION


<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
SQA artifacts currently take around 3h30 to build, and the timeout is set for 4 hours in the Jenkins stage. 
<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
To remove risk of premature failure, increase timeout by 1 more hour.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI