### PR TITLE
NOJIRA: Add GitHub SHA to cache key

### DIFF
--- a/.github/actions/cache-tools/action.yaml
+++ b/.github/actions/cache-tools/action.yaml
@@ -14,7 +14,7 @@ runs:
           id: compute-cache-key
           shell: bash
           run: |
-              echo "cache-key=silabs-zap-slt-tools-${{ runner.os }}-${{ runner.arch }}" >> $GITHUB_OUTPUT
+              echo "cache-key=silabs-zap-slt-tools-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}" >> $GITHUB_OUTPUT
 
         - name: Restore ZAP and SLT tools cache
           id: cache


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** N/A

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** The cache key generated by every run is same, so in concurrent runs scenario one run finishing early can delete the cache key for the other run.
Slack thread for reference - https://silabsiot.slack.com/archives/C08BYL4JACS/p1778854838519679

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
- Added ${{ github.sha }} in the cache key, so each workflow run is keyed to the commit it checks out.
- Workflows that consume this action (builder.yaml, dev-apps-builder.yaml) already use the action’s cache-key output (including the delete-cache job in dev-apps-builder.yaml), so they stay aligned without further edits.


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
- Will be tested in the PR CI.