### PR TITLE
[Wake-on-Matter] Fix VCOM issue ot-ncp

### DIFF
--- a/slc/apps/wake_on_matter/thread/matter_thread_soc_wake_on_matter_freertos.slcp
+++ b/slc/apps/wake_on_matter/thread/matter_thread_soc_wake_on_matter_freertos.slcp
@@ -45,6 +45,7 @@ component:
   - id: matter_network_commissioning
   - id: matter_operational_credentials
   - id: matter_log_uart
+  - id: matter_read_client
 
   - id: matter
   - id: matter_platform_mg
@@ -65,10 +66,13 @@ component:
     condition: [matter_platform_mg, device_series_3]
 
   # OT-NCP components
+  - id: clock_manager
+  - id: ot_reset_utils
   - id: mbedtls_jpake
   - id: mbedtls_tls
   - id: mbedtls_dtls
   - id: ot_ncp_source
+  - id: ot_cli_source
   - id: iostream_usart
     instance:
       - vcom # Temp fix for Matter CLI
@@ -137,6 +141,9 @@ define:
 configuration:
   - name: SL_BOARD_ENABLE_VCOM
     value: '1'
+  - name: SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE
+    value: '1024'
+    condition: [device_series_2]  
   - name: SL_BT_CONFIG_USER_ADVERTISERS
     value: 2
     condition: [matter_ble_side_channel]
@@ -145,13 +152,10 @@ configuration:
     condition: [device_series_3]
   - name: SL_OPENTHREAD_ENABLE_APP_TASK
     value: 0
-  - name: SL_OPENTHREAD_ENABLE_CLI_TASK
-    value: 0
-  - name: OPENTHREAD_CONFIG_LOG_OUTPUT
-    value: OPENTHREAD_CONFIG_LOG_OUTPUT_APP
+  - name: SL_OPENTHREAD_ENABLE_SERIAL_TASK
+    value: 1
   - name: SL_MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
     value: 1
-    condition: [matter_thread_cert_libs]
   - name: SL_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
     value: 1
   - name: OPENTHREAD_CONFIG_COAP_API_ENABLE
@@ -207,7 +211,7 @@ configuration:
   # This setup works because the VCOM instance for OT-CLI uses the IOSTREAM driver 
   # while the vcom instance for Matter uses the legacy UARTDRV. This is a stop gap solution until this samples app support CPC.
   - name: SL_IOSTREAM_USART_VCOM_BAUDRATE
-    value: 115200
+    value: 460800
   - name: SL_IOSTREAM_USART_VCOM_FLOW_CONTROL_TYPE
     value: usartHwFlowControlCtsAndRts  
   - name: EMDRV_UARTDRV_FLOW_CONTROL_ENABLE

--- a/slc/apps/wake_on_matter/thread/matter_thread_soc_wake_on_matter_freertos.slcp
+++ b/slc/apps/wake_on_matter/thread/matter_thread_soc_wake_on_matter_freertos.slcp
@@ -66,7 +66,6 @@ component:
     condition: [matter_platform_mg, device_series_3]
 
   # OT-NCP components
-  - id: clock_manager
   - id: ot_reset_utils
   - id: mbedtls_jpake
   - id: mbedtls_tls
@@ -143,7 +142,7 @@ configuration:
     value: '1'
   - name: SL_IOSTREAM_USART_VCOM_RX_BUFFER_SIZE
     value: '1024'
-    condition: [device_series_2]  
+    condition: [device_series_2]
   - name: SL_BT_CONFIG_USER_ADVERTISERS
     value: 2
     condition: [matter_ble_side_channel]


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->
Linux host was not able to received anything pas the first few command.
<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
None
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Matter side was working (commissioning etc...) but the Linux host was not able to interact with the NCP portion of the stack
<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Fix by enabling the serial task to process iostream on the OT-NCP side in a context of a RTOS
Increase the NCP buffer size to take into account the presence of Matter

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**

Tested locally. OT-CTL commands works on the Linux host, Matter shell is available on the other uart