### PR TITLE
fix power consumption with our boards

### DIFF
--- a/slc/component/matter-platform/matter_platform_mg.slcc
+++ b/slc/component/matter-platform/matter_platform_mg.slcc
@@ -55,6 +55,7 @@ requires:
   - name: nvm3_default
   - name: mpu
   - name: udelay
+  - name: mx25_flash_shutdown_eusart 
   - name: component_catalog
   - name: rail_lib_multiprotocol
   - name: rail_util_pti


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->
Turns out the external flash was not disabled by default anymore 🤔 
<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
None
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
EM2 current were around 10uA instead of ~4uA
<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**

Shutdown the external flash by default on MG platform
<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Current was tested locally with a multi-sensor app built for low power.