### PR TITLE
[Matter-6348] Change Solution description for icd sample apps

### DIFF
--- a/slc/apps/air_quality_sensor_app/thread/matter_thread_soc_air_quality_sensor_app_series_2_freertos.slcw
+++ b/slc/apps/air_quality_sensor_app/thread/matter_thread_soc_air_quality_sensor_app_series_2_freertos.slcw
@@ -2,7 +2,7 @@ workspace_name: matter_thread_soc_air_quality_sensor_app_series_2_freertos
 label: Matter Thread - SoC Air Quality Sensor with external Bootloader FreeRTOS
 quality: production
 package: matter
-description: Demonstrates a sample implementation of a Matter over Thread air quality sensor app with external bootloader
+description: Demonstrates a sample implementation of a Matter over Thread air quality sensor app with external bootloader. This configuration will increase power usage in EM2.
 project:
   - path: ./matter_thread_soc_air_quality_sensor_app_freertos.slcp
     id: application

--- a/slc/apps/closure_app/thread/matter_thread_soc_closure_app_series_2_freertos.slcw
+++ b/slc/apps/closure_app/thread/matter_thread_soc_closure_app_series_2_freertos.slcw
@@ -2,7 +2,7 @@ workspace_name: matter_thread_soc_closure_app_series_2_freertos
 label: Matter Thread - SoC Closure with external Bootloader FreeRTOS
 quality: production
 package: matter
-description: Demonstrates a sample implementation of a Matter over Thread closure app with external bootloader
+description: Demonstrates a sample implementation of a Matter over Thread closure app with external bootloader. This configuration will increase power usage in EM2.
 project:
   - path: ./matter_thread_soc_closure_app_freertos.slcp
     id: application

--- a/slc/apps/light_switch_app/thread/matter_thread_soc_light_switch_app_series_2_freertos.slcw
+++ b/slc/apps/light_switch_app/thread/matter_thread_soc_light_switch_app_series_2_freertos.slcw
@@ -2,7 +2,7 @@ workspace_name: matter_thread_soc_light_switch_app_series_2_freertos
 label: Matter Thread - SoC Light Switch with external Bootloader FreeRTOS
 quality: production
 package: matter
-description: Demonstrates a sample implementation of a Matter over Thread light switch app with external bootloader
+description: Demonstrates a sample implementation of a Matter over Thread light switch app with external bootloader. This configuration will increase power usage in EM2.
 project:
   - path: ./matter_thread_soc_light_switch_app_freertos.slcp
     id: application

--- a/slc/apps/lock_app/thread/matter_thread_soc_lock_app_series_2_freertos.slcw
+++ b/slc/apps/lock_app/thread/matter_thread_soc_lock_app_series_2_freertos.slcw
@@ -2,7 +2,7 @@ workspace_name: matter_thread_soc_lock_app_series_2_freertos
 label: Matter Thread - SoC Lock with external Bootloader FreeRTOS
 quality: production
 package: matter
-description: Demonstrates a sample implementation of a Matter over Thread door lock app with external bootloader
+description: Demonstrates a sample implementation of a Matter over Thread door lock app with external bootloader. This configuration will increase power usage in EM2.
 project:
   - path: ./matter_thread_soc_lock_app_freertos.slcp
     id: application

--- a/slc/apps/multi_sensor_app/thread/matter_thread_soc_multi_sensor_app_series_2_freertos.slcw
+++ b/slc/apps/multi_sensor_app/thread/matter_thread_soc_multi_sensor_app_series_2_freertos.slcw
@@ -2,7 +2,7 @@ workspace_name: matter_thread_soc_multi_sensor_app_series_2_freertos
 label: Matter Thread - SoC Multi Sensor with external Bootloader FreeRTOS
 quality: production
 package: matter
-description: Demonstrates a sample implementation of a Matter over Thread multi-sensor app with external bootloader
+description: Demonstrates a sample implementation of a Matter over Thread multi-sensor app with external bootloader. This configuration will increase power usage in EM2.
 project:
   - path: ./matter_thread_soc_multi_sensor_app_freertos.slcp
     id: application

--- a/slc/apps/window_app/thread/matter_thread_soc_window_app_series_2_freertos.slcw
+++ b/slc/apps/window_app/thread/matter_thread_soc_window_app_series_2_freertos.slcw
@@ -1,5 +1,5 @@
 workspace_name: matter_thread_soc_window_app_series_2_freertos
-label: Matter Thread - SoC Window app with external bootloader. This configuration will increase power usage in EM2. FreeRTOS
+label: Matter Thread - SoC Window App with external Bootloader FreeRTOS
 quality: production
 package: matter
 description: Demonstrates a sample implementation of a Matter over Thread window covering app with external bootloader. This configuration will increase power usage in EM2.

--- a/slc/apps/window_app/thread/matter_thread_soc_window_app_series_2_freertos.slcw
+++ b/slc/apps/window_app/thread/matter_thread_soc_window_app_series_2_freertos.slcw
@@ -1,8 +1,8 @@
 workspace_name: matter_thread_soc_window_app_series_2_freertos
-label: Matter Thread - SoC Window App with external Bootloader FreeRTOS
+label: Matter Thread - SoC Window app with external bootloader. This configuration will increase power usage in EM2. FreeRTOS
 quality: production
 package: matter
-description: Demonstrates a sample implementation of a Matter over Thread window covering app with external bootloader
+description: Demonstrates a sample implementation of a Matter over Thread window covering app with external bootloader. This configuration will increase power usage in EM2.
 project:
   - path: ./matter_thread_soc_window_app_freertos.slcp
     id: application


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
Fixes : 
Matter-6348
Matter-6376
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
By default our solution builds for the external storage which enables SPI flash causing a power increase of 7uA. This puts us far above the competition at around 12uA for "sleep" current while Nordic is around 4uA. 
<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Changing the bootloader for the ICD sample apps from `external` to `internal` reduces the idle current from 12uA to ~4-5uA much closer to the competition.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Tested with a MG24 BRD4187C