### PR TITLE
Fix thermostat slcp metadata

### DIFF
--- a/slc/apps/thermostat/wifi/matter_wifi_917_ncp_thermostat_freertos.slcp
+++ b/slc/apps/thermostat/wifi/matter_wifi_917_ncp_thermostat_freertos.slcp
@@ -162,7 +162,7 @@ toolchain_settings:
 filter:
   - name: Type
     value:
-      - NCP
+      - NCP Project
   - name: Difficulty
     value:
       - Advanced
@@ -170,15 +170,22 @@ filter:
     value:
       - Matter
 
+tag:
+  - prebuilt_demo
+  - hardware:rf:band:2400
+  - hardware:component:button:2+
+  - hardware:component:led:2+
+  - hwfilter:device:device_supports_bluetooth
+  - hwfilter:device:device_supports_thread
+  - hwfilter:device:device_series_2
+  - hidden
+
 readme:
   - path: ./README_WiFi.md
 ui_hints:
   highlight:
     - path: README_WiFi.md
       focus: false
-
-tag:
-  - hardware:component:led:2+
 
 post_build:
   profile: application


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
n/a

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
some metadata in thermostat slcp file got reverted in last commit to main 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
add metadata back to slcp file 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to `.slcp` metadata (filters/tags) and do not affect application code or runtime behavior.
> 
> **Overview**
> Restores metadata in `matter_wifi_917_ncp_thermostat_freertos.slcp` by updating the `Type` filter from `NCP` to **`NCP Project`** and re-adding a full `tag` list (prebuilt demo + hardware/hwfilter tags, including `hidden`).
> 
> This ensures the thermostat WiFi NCP project is categorized and discoverable correctly in tooling without changing build logic or source code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51c834ee11f3aa1ab41fd449bd01c128dbe1ba09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->