### PR TITLE
MATTER-5957: Project upgrades platform template

### DIFF
--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -212,7 +212,7 @@ pipeline
         stage('Trigger SQA Smoke Pipeline')
         {
             when {
-                expression { env.BRANCH_NAME == "main" || env.BRANCH_NAME.startsWith("release_") }
+                expression { env.BRANCH_NAME == "main" || env.BRANCH_NAME.startsWith("release_") || env.BRANCH_NAME.startsWith("project_upgrades_")}
             }
             steps {
                 script {

--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -212,7 +212,7 @@ pipeline
         stage('Trigger SQA Smoke Pipeline')
         {
             when {
-                expression { env.BRANCH_NAME == "main" || env.BRANCH_NAME.startsWith("release_") || env.BRANCH_NAME.startsWith("project_upgrades_")}
+                expression { env.BRANCH_NAME == "main" || env.BRANCH_NAME.startsWith("release_") }
             }
             steps {
                 script {

--- a/jenkins_integration/jenkinsFunctions.groovy
+++ b/jenkins_integration/jenkinsFunctions.groovy
@@ -403,7 +403,7 @@ def trigger_sqa_pipelines(pipeline_type)
 {
     if(sqaFunctions.isProductionJenkinsServer())
     {
-        def smoke_list = ['smoke-thread', 'smoke-wifi', 'smoke-cmp']
+        def smoke_list = ['smoke']
         def regression_list = ['feature-thread', 'feature-wifi', 'feature-cmp', 'regression-thread', 'regression-wifi', 'regression-cmp',
                                'regression-ota-thread', 'regression-ota-wifi', 'regression-ota-cmp', 'regression-metrics',
                                'ext-regression-thread', 'ext-regression-wifi', 'ext-regression-cmp',

--- a/jenkins_integration/jenkinsFunctions.groovy
+++ b/jenkins_integration/jenkinsFunctions.groovy
@@ -403,7 +403,7 @@ def trigger_sqa_pipelines(pipeline_type)
 {
     if(sqaFunctions.isProductionJenkinsServer())
     {
-        def smoke_list = ['smoke']
+        def smoke_list = ['smoke-thread', 'smoke-wifi', 'smoke-cmp']
         def regression_list = ['feature-thread', 'feature-wifi', 'feature-cmp', 'regression-thread', 'regression-wifi', 'regression-cmp',
                                'regression-ota-thread', 'regression-ota-wifi', 'regression-ota-cmp', 'regression-metrics',
                                'ext-regression-thread', 'ext-regression-wifi', 'ext-regression-cmp',

--- a/slc/apps/platform_template/thread/README.md
+++ b/slc/apps/platform_template/thread/README.md
@@ -7,6 +7,7 @@ A minimal Matter over Thread platform example with essential clusters on Silicon
 - [Purpose/Scope](#purposescope)
 - [Prerequisites/Setup Requirements](#prerequisitessetup-requirements)
 - [Steps to Run Demo](#steps-to-run-demo)
+- [Extending Base App Implementation](#extending-base-app-implementation)
 - [Troubleshooting](#troubleshooting)
 - [Resources](#resources)
 - [Report Bugs & Get Support](#report-bugs--get-support)
@@ -57,6 +58,118 @@ This sample app works out of the box with no additional configuration required. 
 **Button and LED reference:**
 
 This app does not define application-specific buttons or LEDs. If WSTK LED Support is installed, LED 0 may indicate commissioning/connectivity state.
+
+## Extending Base App Implementation
+
+### CustomerAppTask
+
+To implement custom app behavior you can override any Silicon Labs implemented API in the CustomerAppTask file. This example provides `CustomerAppTask.h` and `CustomerAppTask.cpp` for that purpose. The base implementation and the full set of overridable `*Impl()` APIs are supplied by the build system in `AppTask.cpp` and `AppTaskImpl.h` under `autogen/`. Any `*Impl()` you do not override keeps the Silicon Labs default behavior.
+
+### How to Override APIs
+
+`CustomerAppTask` derives from the base AppTask through the Curiously Recurring
+Template Pattern (CRTP). You override only the `*Impl()` methods you need, the
+base declares one `*Impl()` per overridable API. Steps:
+
+1. Find the method to override in the base API (see
+   [Override API reference](#override-api-reference) below).
+2. Declare the same method signature in `CustomerAppTask` in your
+   `CustomerAppTask.h` under `private:`. Match the base `*Impl()` signature
+   exactly — note that `*Impl()` overrides are **non-static instance methods**
+   even when the public dispatcher (e.g. `ButtonEventHandler`) is `static`.
+3. Implement the method in `CustomerAppTask.cpp`.
+4. Build. The CRTP layer automatically routes each call to your `*Impl()` if
+   present, otherwise to the Silicon Labs default.
+
+### Sample Implementation
+
+The following shows a minimal example `CustomerAppTask` that overrides
+`AppInitImpl()` and `ButtonEventHandlerImpl()`.
+
+**CustomerAppTask.h**
+
+```cpp
+#pragma once
+#include "AppTaskImpl.h"
+
+/**
+ * Minimal AppTaskImpl-derived class. Override only the *Impl() methods you need **/
+class CustomerAppTask : public AppTaskImpl<CustomerAppTask>
+{
+public:
+    static CustomerAppTask & GetAppTask() { return sAppTask; }
+
+private:
+    friend class AppTaskImpl<CustomerAppTask>;
+    CHIP_ERROR AppInitImpl();
+    void ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction);
+    static CustomerAppTask sAppTask;
+};
+```
+
+**CustomerAppTask.cpp**
+
+```cpp
+#include "CustomerAppTask.h"
+#include "AppTask.h"
+#include "AppConfig.h"
+#include "AppEvent.h"
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/silabs/platformAbstraction/SilabsPlatform.h>
+
+using namespace ::chip::DeviceLayer::Silabs;
+
+#define APP_FUNCTION_BUTTON 0
+#define APP_USER_ACTION 1
+
+CustomerAppTask CustomerAppTask::sAppTask;
+
+AppTask & AppTask::GetAppTask()
+{
+    return CustomerAppTask::GetAppTask();
+}
+
+CHIP_ERROR CustomerAppTask::AppInitImpl()
+{
+    SILABS_LOG("CustomerAppTask: custom implementation (AppInitImpl)");
+    CHIP_ERROR err = AppTask::AppInit();
+    if (err == CHIP_NO_ERROR)
+    {
+        // Override the SDK default button handler registered in AppTask::AppInit().
+        chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(CustomerAppTask::ButtonEventHandler);
+    }
+    return err;
+}
+
+void CustomerAppTask::ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction)
+{
+    SILABS_LOG("CustomerAppTask: custom implementation (ButtonEventHandlerImpl)");
+    AppEvent button_event           = {};
+    button_event.Type               = AppEvent::kEventType_Button;
+    button_event.ButtonEvent.Action = btnAction;
+
+    if (button == APP_USER_ACTION)
+    {
+        button_event.Handler = &CustomerAppTask::ApplicationEventHandler;
+        AppTask::GetAppTask().PostEvent(&button_event);
+    }
+    if (button == APP_FUNCTION_BUTTON)
+    {
+        button_event.Handler = BaseApplication::ButtonHandler;
+        AppTask::GetAppTask().PostEvent(&button_event);
+    }
+}
+```
+
+### Override API Reference
+
+The base API and implementation are generated into your project and live under `autogen/` directory. These files are regenerated on every project upgrade and match your installed SDK version. Use them as the reference for overridable methods and app configuration.
+
+| File | Purpose |
+|------|--------|
+| `autogen/AppTaskImpl.h` | Declarations of every overridable `*Impl()` method. Copy the signatures you need from here into `CustomerAppTask.h`. |
+| `autogen/AppTask.cpp` | Silicon Labs default implementation of AppTask. This is what runs for any `*Impl()` you do not override. Use as reference when customizing behavior. |
+
 
 ## Troubleshooting
 

--- a/slc/apps/platform_template/thread/matter_thread_soc_platform_template_freertos.slcp
+++ b/slc/apps/platform_template/thread/matter_thread_soc_platform_template_freertos.slcp
@@ -88,12 +88,16 @@ include:
     file_list:
       - path: AppConfig.h
       - path: AppEvent.h
-      - path: AppTask.h
       - path: CHIPProjectConfig.h
     directory: include
 
+  - path: ../../../../third_party/matter_sdk/examples/platform/silabs/customer
+    file_list:
+      - path: CustomerAppTask.h
+    directory: include
+
 source:
-  - path: ../../../../third_party/matter_sdk/examples/base-platform-app/silabs/src/AppTask.cpp
+  - path: ../../../../third_party/matter_sdk/examples/platform/silabs/customer/CustomerAppTask.cpp
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src

--- a/slc/apps/platform_template/thread/matter_thread_soc_platform_template_freertos.slcp
+++ b/slc/apps/platform_template/thread/matter_thread_soc_platform_template_freertos.slcp
@@ -111,6 +111,10 @@ define:
     value: "40960"
   - name: NVM3_DEFAULT_MAX_OBJECT_SIZE
     value: "4092"
+  - name: CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE
+    value: 4
+    condition: [matter_icd_core]
+
 configuration:
   - name: SL_BT_CONFIG_USER_ADVERTISERS
     value: 2

--- a/slc/apps/platform_template/wifi/README.md
+++ b/slc/apps/platform_template/wifi/README.md
@@ -7,6 +7,7 @@ A minimal Matter over Wi-Fi platform example with essential clusters on Silicon 
 - [Purpose/Scope](#purposescope)
 - [Prerequisites/Setup Requirements](#prerequisitessetup-requirements)
 - [Steps to Run Demo](#steps-to-run-demo)
+- [Extending Base App Implementation](#extending-base-app-implementation)
 - [Troubleshooting](#troubleshooting)
 - [Resources](#resources)
 - [Report Bugs & Get Support](#report-bugs--get-support)
@@ -53,6 +54,117 @@ This sample app works out of the box with no additional configuration required. 
 **Button and LED reference:**
 
 This app does not define application-specific buttons or LEDs. If WSTK LED Support is installed, LED 0 may indicate commissioning/connectivity state.
+
+## Extending Base App Implementation
+
+### CustomerAppTask
+
+To implement custom app behavior you can override any Silicon Labs implemented API in the CustomerAppTask file. This example provides `CustomerAppTask.h` and `CustomerAppTask.cpp` for that purpose. The base implementation and the full set of overridable `*Impl()` APIs are supplied by the build system in `AppTask.cpp` and `AppTaskImpl.h` under `autogen/`. Any `*Impl()` you do not override keeps the Silicon Labs default behavior.
+
+### How to Override APIs
+
+`CustomerAppTask` derives from the base AppTask through the Curiously Recurring
+Template Pattern (CRTP). You override only the `*Impl()` methods you need, the
+base declares one `*Impl()` per overridable API. Steps:
+
+1. Find the method to override in the base API (see
+   [Override API reference](#override-api-reference) below).
+2. Declare the same method signature in `CustomerAppTask` in your
+   `CustomerAppTask.h` under `private:`. Match the base `*Impl()` signature
+   exactly — note that `*Impl()` overrides are **non-static instance methods**
+   even when the public dispatcher (e.g. `ButtonEventHandler`) is `static`.
+3. Implement the method in `CustomerAppTask.cpp`.
+4. Build. The CRTP layer automatically routes each call to your `*Impl()` if
+   present, otherwise to the Silicon Labs default.
+
+### Sample Implementation
+
+The following shows a minimal example `CustomerAppTask` that overrides
+`AppInitImpl()` and `ButtonEventHandlerImpl()`.
+
+**CustomerAppTask.h**
+
+```cpp
+#pragma once
+#include "AppTaskImpl.h"
+
+/**
+ * Minimal AppTaskImpl-derived class. Override only the *Impl() methods you need **/
+class CustomerAppTask : public AppTaskImpl<CustomerAppTask>
+{
+public:
+    static CustomerAppTask & GetAppTask() { return sAppTask; }
+
+private:
+    friend class AppTaskImpl<CustomerAppTask>;
+    CHIP_ERROR AppInitImpl();
+    void ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction);
+    static CustomerAppTask sAppTask;
+};
+```
+
+**CustomerAppTask.cpp**
+
+```cpp
+#include "CustomerAppTask.h"
+#include "AppTask.h"
+#include "AppConfig.h"
+#include "AppEvent.h"
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/silabs/platformAbstraction/SilabsPlatform.h>
+
+using namespace ::chip::DeviceLayer::Silabs;
+
+#define APP_FUNCTION_BUTTON 0
+#define APP_USER_ACTION 1
+
+CustomerAppTask CustomerAppTask::sAppTask;
+
+AppTask & AppTask::GetAppTask()
+{
+    return CustomerAppTask::GetAppTask();
+}
+
+CHIP_ERROR CustomerAppTask::AppInitImpl()
+{
+    SILABS_LOG("CustomerAppTask: custom implementation (AppInitImpl)");
+    CHIP_ERROR err = AppTask::AppInit();
+    if (err == CHIP_NO_ERROR)
+    {
+        // Override the SDK default button handler registered in AppTask::AppInit().
+        chip::DeviceLayer::Silabs::GetPlatform().SetButtonsCb(CustomerAppTask::ButtonEventHandler);
+    }
+    return err;
+}
+
+void CustomerAppTask::ButtonEventHandlerImpl(uint8_t button, uint8_t btnAction)
+{
+    SILABS_LOG("CustomerAppTask: custom implementation (ButtonEventHandlerImpl)");
+    AppEvent button_event           = {};
+    button_event.Type               = AppEvent::kEventType_Button;
+    button_event.ButtonEvent.Action = btnAction;
+
+    if (button == APP_USER_ACTION)
+    {
+        button_event.Handler = &CustomerAppTask::ApplicationEventHandler;
+        AppTask::GetAppTask().PostEvent(&button_event);
+    }
+    if (button == APP_FUNCTION_BUTTON)
+    {
+        button_event.Handler = BaseApplication::ButtonHandler;
+        AppTask::GetAppTask().PostEvent(&button_event);
+    }
+}
+```
+
+### Override API Reference
+
+The base API and implementation are generated into your project and live under `autogen/` directory. These files are regenerated on every project upgrade and match your installed SDK version. Use them as the reference for overridable methods and app configuration.
+
+| File | Purpose |
+|------|--------|
+| `autogen/AppTaskImpl.h` | Declarations of every overridable `*Impl()` method. Copy the signatures you need from here into `CustomerAppTask.h`. |
+| `autogen/AppTask.cpp` | Silicon Labs default implementation of AppTask. This is what runs for any `*Impl()` you do not override. Use as reference when customizing behavior. |
 
 ## Troubleshooting
 

--- a/slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp
+++ b/slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp
@@ -95,12 +95,16 @@ include:
     file_list:
       - path: AppConfig.h
       - path: AppEvent.h
-      - path: AppTask.h
       - path: CHIPProjectConfig.h
     directory: include
 
+  - path: ../../../../third_party/matter_sdk/examples/platform/silabs/customer
+    file_list:
+      - path: CustomerAppTask.h
+    directory: include
+
 source:
-  - path: ../../../../third_party/matter_sdk/examples/base-platform-app/silabs/src/AppTask.cpp
+  - path: ../../../../third_party/matter_sdk/examples/platform/silabs/customer/CustomerAppTask.cpp
     directory: src
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/main.cpp
     directory: src

--- a/slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp
+++ b/slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp
@@ -123,6 +123,9 @@ define:
     value: "4092"
   - name: SI917_SOC
     value: 1
+  - name: CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE
+    value: 5
+    condition: [matter_icd_core]
   
 configuration:
   - name: SL_ULPUART_DMA_CONFIG_ENABLE

--- a/slc/component/matter-examples/matter_platform_template.slcc
+++ b/slc/component/matter-examples/matter_platform_template.slcc
@@ -7,5 +7,12 @@ id: matter_platform_template
 quality: production
 provides:
   - name: matter_platform_template
+metadata:
+  sbom:
+    license: "Apache 2.0"
+template_file:
+  - path: third_party/matter_sdk/examples/base-platform-app/silabs/include/AppTask.h
+  - path: third_party/matter_sdk/examples/base-platform-app/silabs/include/AppTaskImpl.h
+  - path: third_party/matter_sdk/examples/base-platform-app/silabs/src/AppTask.cpp
 ui_hints:
   visibility: never

--- a/slc/component/matter-wifi/matter_sleep_manager.slcc
+++ b/slc/component/matter-wifi/matter_sleep_manager.slcc
@@ -35,3 +35,5 @@ source:
 define:
   - name: SL_MATTER_ENABLE_APP_SLEEP_MANAGER
     value: 1
+  - name: CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE
+    value: 3

--- a/slc/component/matter-wifi/matter_sleep_manager.slcc
+++ b/slc/component/matter-wifi/matter_sleep_manager.slcc
@@ -35,5 +35,3 @@ source:
 define:
   - name: SL_MATTER_ENABLE_APP_SLEEP_MANAGER
     value: 1
-  - name: CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE
-    value: 3


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
MATTER-5957

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Extension PR to pick up project upgrades refactor for platform template app

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
- Bump submodule to latest matter_sdk 
- Update necessary slcp/slcw files 
- Update README files
- Add pool size definition to slcp, remove from component
  - In matter_sdk if matter_sleep_manager defined then we configure pool size in CHIPPlatformConfig.h
  - This way, component doesn't override app specific pool size needs 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI (full CI and smoke) 
Local testing of overrides
Local test that AppTask observer is registered and overridable 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes platform template build inputs (swapping `AppTask.cpp` for `CustomerAppTask.cpp` and new includes) and adjusts ICD observer pool sizing, which can affect runtime behavior and memory usage for ICD builds.
> 
> **Overview**
> Adds a documented extension point for platform templates by wiring in `CustomerAppTask` (CRTP `*Impl()` overrides) for both Thread and Wi‑Fi apps, updating the READMEs with override guidance and sample code.
> 
> Updates the Thread/Wi‑Fi `.slcp` projects to include the new customer header/source, stop directly compiling the base `AppTask.cpp`, and set `CHIP_CONFIG_ICD_OBSERVERS_POOL_SIZE` per-app for ICD builds. Also adds SBOM license metadata to `matter_platform_template.slcc` and removes the observer pool size define from the `matter_sleep_manager` component so apps control sizing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1d99be32e7b0249b7dc4cc0ded3e4f3dd7b0350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->