### PR TITLE
MATTER-6482: Disable the LTO builds for the 917SoC

### DIFF
--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -34,18 +34,6 @@
                 "arguments": ["--output_suffix copy-sources", "--copy-sources"]
             }
         ],
-        "lighting_app": [
-            {
-                "boards": ["brd4338a"],
-                "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
-            }
-        ],
-        "lock_app": [
-            {
-                "boards": ["brd4338a"],
-                "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
-            }
-        ],
         "platform_template": [
             {
                 "boards": ["brd4338a", "brd4343a", "brd4342a"],
@@ -79,16 +67,6 @@
                 "arguments": ["--output_suffix m-ota-enc",
                               "--without_app matter_ota_support",
                               "--with_app matter_multi_image_ota,matter_multi_image_ota_encryption,matter_multi_image_custom_processor"]
-            },
-            {
-                "boards": ["brd4338a", "brd4342a", "brd4343a"],
-                "arguments": ["--output_suffix sqa-lto",
-                              "--with_app toolchain_gcc_lto"]
-            },
-            {
-                "boards": ["brd4338a", "brd4342a"],
-                "arguments": ["--output_suffix sqa-lto-ota-2", "--with_app toolchain_gcc_lto",
-                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ],
         "lock_app" :[
@@ -96,11 +74,6 @@
                 "boards": ["brd4338a", "brd4342a", "brd4343a"],
                 "arguments": ["--output_suffix ota-2",
                               "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
-            },
-            {
-                "boards": ["brd4338a", "brd4342a", "brd4343a"],
-                "arguments": ["--output_suffix sqa-lto",
-                              "--with_app toolchain_gcc_lto"]
             },
             {
                 "boards": ["brd4338a"],


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
MATTER-6482

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
LTO builds are failing with the build 630 of the SiSDK and Wiseconnect

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Temporarily disabling the LTO builds till it is fixed.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI