### PR TITLE
MATTER-6487 :Add conflict

### DIFF
--- a/slc/component/matter-core-sdk/matter_check_in_sender.slcc
+++ b/slc/component/matter-core-sdk/matter_check_in_sender.slcc
@@ -29,7 +29,7 @@ source:
 requires:
   - name: matter_icd_core
 conflicts:
-  - name: matter_icd_checkin_sender
+  - name: ot_stack_ftd
 
 ui_hints:
   visibility: never

--- a/slc/component/matter-core-sdk/matter_check_in_sender.slcc
+++ b/slc/component/matter-core-sdk/matter_check_in_sender.slcc
@@ -28,6 +28,8 @@ source:
   - path: third_party/matter_sdk/src/app/icd/server/ICDCheckInSender.cpp
 requires:
   - name: matter_icd_core
+conflicts:
+  - name: matter_icd_checkin_sender
 
 ui_hints:
   visibility: never

--- a/slc/component/matter-platform/low-power/matter_icd_checkin_sender.slcc
+++ b/slc/component/matter-platform/low-power/matter_icd_checkin_sender.slcc
@@ -30,6 +30,9 @@ requires:
   - name: matter_icd_core
   - name: matter_check_in_message
 
+conflicts:
+  - name: matter_check_in_sender
+
 documentation:
   docset: matter
   document: matter-overview-guides/matter-icd

--- a/slc/component/matter-platform/low-power/matter_icd_checkin_sender.slcc
+++ b/slc/component/matter-platform/low-power/matter_icd_checkin_sender.slcc
@@ -31,7 +31,7 @@ requires:
   - name: matter_check_in_message
 
 conflicts:
-  - name: matter_check_in_sender
+  - name: ot_stack_ftd
 
 documentation:
   docset: matter

--- a/slc/component/matter-platform/low-power/matter_icd_core.slcc
+++ b/slc/component/matter-platform/low-power/matter_icd_core.slcc
@@ -30,12 +30,6 @@ requires:
 conflicts:
   - name: ot_stack_ftd
 
-recommends:
-  - id: ot_stack_mtd
-    vendor: silabs
-    condition:
-      - matter_thread
-
 config_file:
   - path: slc/config/sl_matter_icd_config.h
     file_id: matter_icd_config


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
[MATTER-6487](https://jira.silabs.com/browse/MATTER-6487)

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Need to add explicit conflicts on root components to help autoselect dependencies while resolving a conflict in SLC

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Added a conflict on `ot_stack_ftd` for matter_check_in_sender and matter_icd_checkin_sender

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Tested by 
1. Loading 2.9.0-RC1 in studio to reproduce the issue, i.e create a multisensor project for brd4351a and try to install ot_ftd and run into infinite loop as referred in https://jira.silabs.com/browse/MCUDT-37209 
2. Loading the staged extension from this PR and tries the same , now able to replace and install the ot_ftd