### PR TITLE
Enable SQA validation for the watchdog manager.

### DIFF
--- a/.github/silabs-builds-mg24.json
+++ b/.github/silabs-builds-mg24.json
@@ -14,7 +14,7 @@
         "zigbee_light": [
             {
                 "boards": ["brd4187c"],
-                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential"] 
+                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential"]
             },
             {
                 "boards": ["brd4187c"],
@@ -24,11 +24,11 @@
         "platform_template": [
             {
                 "boards": ["brd4187c"],
-                "arguments": ["--output_suffix peripherals","--with_app matter_peripherals"] 
+                "arguments": ["--output_suffix peripherals","--with_app matter_peripherals"]
             },
             {
                 "boards": ["brd4187c"],
-                "arguments": ["--output_suffix peripherals-icd","--with_app matter_peripherals,matter_icd_core"]  
+                "arguments": ["--output_suffix peripherals-icd","--with_app matter_peripherals,matter_icd_core"]
             }
         ],
         "thermostat": [
@@ -60,7 +60,7 @@
             },
             {
                 "boards": ["brd4187c"],
-                "arguments": ["--output_suffix multipan","--with_app matter_multipan_internal"] 
+                "arguments": ["--output_suffix multipan","--with_app matter_multipan_internal"]
             },
             {
                 "boards": ["brd4187c"],
@@ -76,11 +76,11 @@
         "zigbee_light":  [
             {
                 "boards": ["brd4186c", "brd4187c", "brd2601b"],
-                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential"] 
+                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential"]
             },
             {
                 "boards": ["brd4186c"],
-                "arguments": ["--output_suffix sequential-copy-sources","--with_app matter_zigbee_sequential", "--copy-sources"] 
+                "arguments": ["--output_suffix sequential-copy-sources","--with_app matter_zigbee_sequential", "--copy-sources"]
             },
             {
                 "boards": ["brd4187c"],
@@ -94,11 +94,11 @@
             },
             {
                 "boards": ["brd4187c"],
-                "arguments": ["--output_suffix peripherals-icd","--with_app matter_icd_core,matter_peripherals"] 
+                "arguments": ["--output_suffix peripherals-icd","--with_app matter_icd_core,matter_peripherals"]
             },
             {
                 "boards": ["brd4187c"],
-                "arguments": ["--output_suffix peripherals-icd-copy-sources","--with_app matter_icd_core,matter_peripherals", "--without_app matter_log_rtt", "--copy-sources"] 
+                "arguments": ["--output_suffix peripherals-icd-copy-sources","--with_app matter_icd_core,matter_peripherals", "--without_app matter_log_rtt", "--copy-sources"]
             }
         ],
         "thermostat": [
@@ -127,7 +127,7 @@
             {
                 "boards": ["brd4187c"],
                 "arguments": ["--output_suffix wdog",
-                              "--with_app watchdog_manager"]
+                              "--with_app watchdog_manager,matter_tests"]
             },
             {
                 "boards": ["brd4187c"],
@@ -215,5 +215,5 @@
                               "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ]
-    }  
+    }
 }

--- a/.github/silabs-builds-mg26.json
+++ b/.github/silabs-builds-mg26.json
@@ -14,7 +14,7 @@
         "platform_template": [
             {
                 "boards": ["brd4116a"],
-                "arguments": ["--output_suffix peripherals-icd","--with_app matter_peripherals,matter_icd_core"] 
+                "arguments": ["--output_suffix peripherals-icd","--with_app matter_peripherals,matter_icd_core"]
             }
         ],
         "thermostat": [
@@ -39,11 +39,11 @@
         "zigbee_light":  [
             {
                 "boards": ["brd4116a", "brd4117a", "brd4118a", "brd2608a", "brd4120a", "brd4121a"],
-                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential"] 
+                "arguments": ["--output_suffix sequential","--with_app matter_zigbee_sequential"]
             },
             {
                 "boards": ["brd4116a"],
-                "arguments": ["--output_suffix sequential-copy-sources","--with_app matter_zigbee_sequential", "--copy-sources"] 
+                "arguments": ["--output_suffix sequential-copy-sources","--with_app matter_zigbee_sequential", "--copy-sources"]
             }
         ],
         "platform_template": [
@@ -53,11 +53,11 @@
             },
             {
                 "boards": ["brd4116a"],
-                "arguments": ["--output_suffix peripherals-icd","--with_app matter_peripherals,matter_icd_core"] 
+                "arguments": ["--output_suffix peripherals-icd","--with_app matter_peripherals,matter_icd_core"]
             },
             {
                 "boards": ["brd4116a"],
-                "arguments": ["--output_suffix peripherals-icd-copy-sources","--with_app matter_peripherals,matter_icd_core", "--without_app matter_log_rtt", "--copy-sources"] 
+                "arguments": ["--output_suffix peripherals-icd-copy-sources","--with_app matter_peripherals,matter_icd_core", "--without_app matter_log_rtt", "--copy-sources"]
             },
             {
                 "boards": ["brd4116a"],
@@ -85,7 +85,7 @@
             {
                 "boards": ["brd4116a"],
                 "arguments": ["--output_suffix wdog",
-                              "--with_app watchdog_manager"]
+                              "--with_app watchdog_manager,matter_tests"]
             },
             {
                 "boards": ["brd4116a"],
@@ -256,5 +256,5 @@
                               "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ]
-    } 
+    }
 }

--- a/.github/silabs-builds-sixg301.json
+++ b/.github/silabs-builds-sixg301.json
@@ -35,7 +35,7 @@
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH"],
-                "arguments": ["--output_suffix copy-sources", "--copy-sources"] 
+                "arguments": ["--output_suffix copy-sources", "--copy-sources"]
             }
         ],
         "lighting_app": [
@@ -57,7 +57,7 @@
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH"],
-                "arguments": ["--output_suffix sequential-copy-sources","--with_app matter_zigbee_sequential", "--copy-sources"] 
+                "arguments": ["--output_suffix sequential-copy-sources","--with_app matter_zigbee_sequential", "--copy-sources"]
             },
             {
                 "boards": ["brd4407a"],
@@ -85,7 +85,7 @@
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd2719a", "brd4407a"],
-                "arguments": ["--output_suffix peripherals-icd-copy-sources","--with_app matter_peripherals,matter_icd_core", "--without_app matter_log_rtt", "--copy-sources"] 
+                "arguments": ["--output_suffix peripherals-icd-copy-sources","--with_app matter_peripherals,matter_icd_core", "--without_app matter_log_rtt", "--copy-sources"]
             }
         ]
     },
@@ -99,7 +99,7 @@
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],
                 "arguments": ["--output_suffix wdog", "-pids application",
-                              "--with_app watchdog_manager"]
+                              "--with_app watchdog_manager,matter_tests"]
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],
@@ -160,7 +160,7 @@
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],
                 "arguments": ["--output_suffix cmp-concurrent-wdog", "-pids application",
-                              "--with_app watchdog_manager,matter_zigbee_concurrent"]
+                              "--with_app watchdog_manager,matter_tests,matter_zigbee_concurrent"]
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],
@@ -257,7 +257,7 @@
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],
                 "arguments": ["--output_suffix peripherals-wdog", "-pids application",
-                              "--with_app watchdog_manager"]
+                              "--with_app watchdog_manager,matter_tests"]
             },
             {
                 "boards": ["brd1019a,SIMG301M113WIH", "brd4407a"],

--- a/slc/component/matter-platform/utils/matter_tests.slcc
+++ b/slc/component/matter-platform/utils/matter_tests.slcc
@@ -1,0 +1,16 @@
+id: matter_tests
+label: Matter Test Event Trigger
+description: Enable Test defines for internal tests.
+package: matter
+category: Matter|Utils
+quality: internal
+metadata:
+  sbom:
+    license: Zlib
+
+provides:
+  - name: matter_tests
+
+define:
+  - name: TEST_WATCHDOG
+    condition: [watchdog_manager]

--- a/slc/component/matter-platform/utils/matter_tests.slcc
+++ b/slc/component/matter-platform/utils/matter_tests.slcc
@@ -12,5 +12,7 @@ provides:
   - name: matter_tests
 
 define:
-  - name: TEST_WATCHDOG
+  - name: SL_MATTER_TEST_WATCHDOG
     condition: [watchdog_manager]
+ui_hints:
+  visibility: never

--- a/slc/component/matter-platform/utils/matter_tests.slcc
+++ b/slc/component/matter-platform/utils/matter_tests.slcc
@@ -6,7 +6,7 @@ category: Matter|Utils
 quality: internal
 metadata:
   sbom:
-    license: Zlib
+    license: MSLA
 
 provides:
   - name: matter_tests


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
N/A

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
SQA wants to validate that the `watchdog_manager` integration works within matter apps.
The watchdog can be enabled but if everything works normally, watchdog is "invisible"

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
This PR adds a way to enable a matter shell command that will force a watchdog starvation and lead to a device reboot.
- Matter_sdk bump to bring the new shell command
https://github.com/SiliconLabsSoftware/matter_sdk/pull/978 (To be merged first)
- new component `matter_tests` for **internal use only.** Currently it only adds a define to enable this shell test command when `watchdog_manager` is enabled  but it could be extended for any SQA/Test only configuration.
- Add `matter_tests` component to the SQA builds already enabling the `watchdog_manager`

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
build lighting-app with watchdog _manager and matter_tests
send cli command : watchdog starve.
device will reboot after a few seconds
use chip-tool  to Read generaldiagnostics boot-read on the device.
Get 
```
[1779913092.633] [557268:557270] [TOO] Endpoint: 0 Cluster: 0x0000_0033 Attribute 0x0000_0004 DataVersion: 1536840505
[1779913092.633] [557268:557270] [TOO]   BootReason: 3
```
which is `SoftwareWatchdogReset`