### PR TITLE
MATTER-6482: Re-enable LTO builds for SiWx platform

### DIFF
--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -34,6 +34,18 @@
                 "arguments": ["--output_suffix copy-sources", "--copy-sources"]
             }
         ],
+        "lighting_app": [
+            {
+                "boards": ["brd4338a"],
+                "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
+            }
+        ],
+        "lock_app": [
+            {
+                "boards": ["brd4338a"],
+                "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
+            }
+        ],
         "platform_template": [
             {
                 "boards": ["brd4338a", "brd4343a", "brd4342a"],
@@ -67,6 +79,16 @@
                 "arguments": ["--output_suffix m-ota-enc",
                               "--without_app matter_ota_support",
                               "--with_app matter_multi_image_ota,matter_multi_image_ota_encryption,matter_multi_image_custom_processor"]
+            },
+            {
+                "boards": ["brd4338a", "brd4342a", "brd4343a"],
+                "arguments": ["--output_suffix sqa-lto",
+                              "--with_app toolchain_gcc_lto"]
+            },
+            {
+                "boards": ["brd4338a", "brd4342a"],
+                "arguments": ["--output_suffix sqa-lto-ota-2", "--with_app toolchain_gcc_lto",
+                              "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
             }
         ],
         "lock_app" :[
@@ -74,6 +96,11 @@
                 "boards": ["brd4338a", "brd4342a", "brd4343a"],
                 "arguments": ["--output_suffix ota-2",
                               "'--configuration CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION:2,CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING:\"2\"'"]
+            },
+            {
+                "boards": ["brd4338a", "brd4342a", "brd4343a"],
+                "arguments": ["--output_suffix sqa-lto",
+                              "--with_app toolchain_gcc_lto"]
             },
             {
                 "boards": ["brd4338a"],

--- a/slc/component/matter-core-sdk/siwx917_common.slcc
+++ b/slc/component/matter-core-sdk/siwx917_common.slcc
@@ -44,7 +44,6 @@ source:
   - path: third_party/matter_sdk/examples/platform/silabs/OTAConfig.cpp
   - path: third_party/matter_sdk/examples/platform/silabs/SoftwareFaultReports.cpp
   - path: third_party/matter_sdk/examples/platform/silabs/silabs_utils.cpp
-  - path: third_party/matter_sdk/examples/platform/silabs/syscalls_stubs.cpp
 
 define:
   - name: CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER

--- a/slc/component/matter-platform/matter_platform_siwx917.slcc
+++ b/slc/component/matter-platform/matter_platform_siwx917.slcc
@@ -26,24 +26,25 @@ requires:
   - name: sl_si91x_memory_manager
   - name: psram_core
     condition: [device_supports_psram, device_supports_external_flash]
+  - name: syscalls
 
 provides:
   - name: matter_platform_siwx917
   - name: matter_si91x_common_flash_nvm3_enabled
 
 include:
-- path: third_party/matter_sdk/examples/platform/silabs
-  file_list:
-  - path: PigweedLogger.h
-  - path: Rpc.h
-  - path: silabs_utils.h
-  - path: LEDWidget.h
-  - path: MatterConfig.h
-  - path: OTAConfig.h
-  - path: MemMonitoring.h
-  - path: BaseApplication.h
-  - path: BaseAppEvent.h
-  - path: SoftwareFaultReports.h
+  - path: third_party/matter_sdk/examples/platform/silabs
+    file_list:
+      - path: PigweedLogger.h
+      - path: Rpc.h
+      - path: silabs_utils.h
+      - path: LEDWidget.h
+      - path: MatterConfig.h
+      - path: OTAConfig.h
+      - path: MemMonitoring.h
+      - path: BaseApplication.h
+      - path: BaseAppEvent.h
+      - path: SoftwareFaultReports.h
 source:
   - path: third_party/matter_sdk/examples/platform/silabs/BaseApplication.cpp
   - path: third_party/matter_sdk/examples/platform/silabs/silabs_utils.cpp

--- a/slc/component/matter-platform/utils/matter_syscall_stubs.slcc
+++ b/slc/component/matter-platform/utils/matter_syscall_stubs.slcc
@@ -9,8 +9,13 @@ metadata:
     license: Zlib
 provides:
   - name: matter_syscall_stubs
+requires:
+  - name: syscalls
+    condition: [matter_platform_siwx917]
 source:
   - path: third_party/matter_sdk/examples/platform/silabs/syscalls_stubs.cpp
+    unless: [matter_platform_siwx917]
 toolchain_settings:
   - option: gcc_linker_option
     value: -Wl,--no-warn-rwx-segment
+    unless: [matter_platform_siwx917]

--- a/slc/component/matter-platform/utils/matter_syscall_stubs.slcc
+++ b/slc/component/matter-platform/utils/matter_syscall_stubs.slcc
@@ -9,13 +9,8 @@ metadata:
     license: Zlib
 provides:
   - name: matter_syscall_stubs
-requires:
-  - name: syscalls
-    condition: [matter_platform_siwx917]
 source:
   - path: third_party/matter_sdk/examples/platform/silabs/syscalls_stubs.cpp
-    unless: [matter_platform_siwx917]
 toolchain_settings:
   - option: gcc_linker_option
     value: -Wl,--no-warn-rwx-segment
-    unless: [matter_platform_siwx917]

--- a/slc/component/matter.slcc
+++ b/slc/component/matter.slcc
@@ -120,6 +120,7 @@ requires:
   - name: matter_ot_mbedtls_override
   - name: matter_server_cluster
   - name: matter_syscall_stubs
+    unless: [matter_platform_siwx917]
   - name: matter_nlassert
   - name: matter_nlio
   - name: matter_includes


### PR DESCRIPTION

<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** MATTER-6482

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Components were out of date for the newer Wiseconnect SDK

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Update `syscalls` handling in `matter-core-sdk` and `matter-platform` components for siwx917 builds

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:** CICD builds.