### PR TITLE
Update cache tools version

### DIFF
--- a/.github/actions/cache-tools/action.yaml
+++ b/.github/actions/cache-tools/action.yaml
@@ -18,7 +18,7 @@ runs:
 
         - name: Restore ZAP and SLT tools cache
           id: cache
-          uses: actions/cache/restore@v4
+          uses: actions/cache/restore@v5
           with:
               path: |
                   /tmp/zap-linux-x64
@@ -62,7 +62,7 @@ runs:
 
         - name: Save ZAP and SLT tools cache
           if: steps.cache.outputs.cache-hit != 'true'
-          uses: actions/cache/save@v4
+          uses: actions/cache/save@v5
           with:
               path: |
                   /tmp/zap-linux-x64


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Cache tools were introduced using v4, which uses Node.js 20. tools that use Node.js 20 will have support cut June 2. 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Update to v5 with Node.js 24, cleans up warnings in CI and will avoid any problems come June 2 cutoff 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only CI dependency version pins change; no application or build logic is modified.
> 
> **Overview**
> Bumps the composite **cache-tools** workflow’s GitHub Actions cache steps from **v4** to **v5** for both restore and save, aligning CI with the newer cache action runtime (Node.js 24) ahead of Node 20 deprecation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9ecfda3f32678590d63d90adc5ded3db67a1b2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->