### PR TITLE
Update cache tools version release

### DIFF
--- a/.github/actions/cache-tools/action.yaml
+++ b/.github/actions/cache-tools/action.yaml
@@ -33,7 +33,7 @@ runs:
 
         - name: Restore ZAP and SLT tools cache
           id: cache
-          uses: actions/cache/restore@v4
+          uses: actions/cache/restore@v5
           with:
               path: |
                   /tmp/zap-linux-x64
@@ -77,7 +77,7 @@ runs:
 
         - name: Save ZAP and SLT tools cache
           if: steps.cache.outputs.cache-hit != 'true'
-          uses: actions/cache/save@v4
+          uses: actions/cache/save@v5
           with:
               path: |
                   /tmp/zap-linux-x64


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Cache tools were introduced using v4, which uses Node.js 20. tools that use Node.js 20 will have support cut June 2. 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Update to v5 with Node.js 24, cleans up warnings in CI and will avoid any problems come June 2 cutoff 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only dependency bump with no application or security logic changes.
> 
> **Overview**
> Bumps the composite **cache-tools** workflow from `actions/cache/restore@v4` and `actions/cache/save@v4` to **v5** on both restore and save steps. Cached paths, keys, and install-on-miss behavior are unchanged—only the action major version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21bd25bb99e35e519a86174d070e3631e30b370a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->