### PR TITLE
Fix component generation script

### DIFF
--- a/slc/script/gen_cluster_components.py
+++ b/slc/script/gen_cluster_components.py
@@ -216,7 +216,7 @@ for clustercomponentname in sorted(cluster_data.keys()):
         if len(current_include_data)>1:
             include = {}
             for i in range(len(current_include_data)):
-                if current_include_data[i]["path"] not in cluster_data[clustercomponentname]["include"]:
+                if current_include_data[i]["path"] != cluster_data[clustercomponentname]["include"]:
                     headers = []
                     for header in current_include_data[i]["file_list"]:
                         headers.append(header["path"])


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
`gen_cluster_components.py` preserves manually added include paths when generating component files. however, in recent matter_sdk submodule bump `third_party/matter_sdk/src/app/BufferedReadCallback.h` was removed from `matter_ota_requestor.slcc` on generation which is not expected behavior. the script uses `not in cluster include path` which performs a substring check, causing parent paths (like path to `BufferedReadCallback.h`) which are substrings of cluster include paths to be skipped instead of preserved. 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
compare explicitly against the cluster include path so that only the cluster include path is skipped and regenerated, and all other paths are preserved. 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
locally test script against release_2.9-1.6, verify that BufferedReadCallback.h is preserved
next automated run will preserve this path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line logic fix in a build/codegen script; no runtime auth, data, or product behavior changes.
> 
> **Overview**
> Fixes **cluster component regeneration** so manually added `include` entries in existing `.slcc` files are no longer dropped when their path is a **substring** of the cluster’s default include directory.
> 
> The merge loop in `gen_cluster_components.py` now skips only the exact cluster include path (`!=`) instead of treating any path contained in that string as duplicate (`not in`). That restores expected behavior after Matter SDK bumps—e.g. keeping extra headers like `BufferedReadCallback.h` under `matter_ota_requestor.slcc` while still replacing the auto-generated cluster include block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69dbdf9628f5cb960795700639284eec5a0f3a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->