### PR TITLE
Fix PR validation job

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   check_testing_header:
     runs-on: ubuntu-latest
-    if: ${{ !contains(fromJSON('["dependabot[bot]", "silabs-matter-ci-bot[bot]", "cursoragent", "miduggan24"]'), github.event.pull_request.user.login) }}
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "silabs-matter-ci-bot[bot]", "cursoragent"]'), github.event.pull_request.user.login) }}
     steps:
       - name: Check for "**Testing Done:**" section in PR
         id: check-testing

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -4,10 +4,13 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+env:
+  PR_VALIDATION_SKIP_AUTHORS: '["dependabot[bot]", "silabs-matter-ci-bot[bot]", "cursoragent", "miduggan24"]'
+
 jobs:
   check_testing_header:
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'silabs-matter-ci-bot[bot]' }}
+    if: ${{ !contains(fromJSON(env.PR_VALIDATION_SKIP_AUTHORS), github.event.pull_request.user.login) }}
     steps:
       - name: Check for "**Testing Done:**" section in PR
         id: check-testing

--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -4,13 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
-env:
-  PR_VALIDATION_SKIP_AUTHORS: '["dependabot[bot]", "silabs-matter-ci-bot[bot]", "cursoragent", "miduggan24"]'
-
 jobs:
   check_testing_header:
     runs-on: ubuntu-latest
-    if: ${{ !contains(fromJSON(env.PR_VALIDATION_SKIP_AUTHORS), github.event.pull_request.user.login) }}
+    if: ${{ !contains(fromJSON('["dependabot[bot]", "silabs-matter-ci-bot[bot]", "cursoragent", "miduggan24"]'), github.event.pull_request.user.login) }}
     steps:
       - name: Check for "**Testing Done:**" section in PR
         id: check-testing


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
PR validation job previously used `github.actor` to determine whether or not to run the job. This means that if bot opens PR, but user pushes a commit to it, workflow picks up latest commit and runs the job failing bc bot opened description doesn't match template. 

See example: https://github.com/SiliconLabsSoftware/matter_extension/pull/776

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Use `github.event.pull_request.user.login` to determine when to skip, will apply to any bot opened PR regardless of who commits to it. 

Also add a few more bots we use 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Tested with my user, validated PR validity skipped

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow condition change with no application or security logic impact.
> 
> **Overview**
> The PR validity workflow’s **Testing Done** / **Description of Fix/Solution** header job no longer keys off `github.actor` and instead skips when the **pull request author** (`github.event.pull_request.user.login`) is in a fixed allowlist.
> 
> The allowlist now includes `dependabot[bot]`, `silabs-matter-ci-bot[bot]`, `cursoragent`, and `miduggan24`, so automated and designated accounts are not blocked by the template checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12a8b3c6e41f9cf0bebea994b7f298ad99d75bbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->