### PR TITLE
[MATTER-6495] Move Performance Test cluster to EP1

### DIFF
--- a/silabs_utils/performance_test_commands.cpp
+++ b/silabs_utils/performance_test_commands.cpp
@@ -185,7 +185,7 @@ void MatterPerfTest::PingPerfTestOnConnnection(Messaging::ExchangeManager & exch
     requestsSent++;
     pingStartTime = chip::System::SystemClock().GetMonotonicMilliseconds64().count();
 
-    err = Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, chip::EndpointId(0), EmptyCommand, onSuccess, onFailure,
+    err = Controller::InvokeCommandRequest(&exchangeMgr, sessionHandle, chip::EndpointId(1), EmptyCommand, onSuccess, onFailure,
                                            NullOptional,
                                            MakeOptional(chip::System::Clock::Timeout(timeoutMs)));
 

--- a/slc/apps/performance_test_app/thread/README.md
+++ b/slc/apps/performance_test_app/thread/README.md
@@ -1,6 +1,6 @@
 # Matter over Thread Performance Test Example
 
-Matter performance testing via "perf ping" and "perf mx" Matter Shell commands. Sender and receiver use the Performance Testing cluster on Endpoint 0.
+Matter performance testing via "perf ping" and "perf mx" Matter Shell commands. Sender and receiver use the Performance Testing cluster on Endpoint 1.
 
 ## Table of Contents
 
@@ -13,9 +13,9 @@ Matter performance testing via "perf ping" and "perf mx" Matter Shell commands. 
 
 ## Purpose/Scope
 
-This example enables Matter performance testing on Silicon Labs EFR32 SoC over Thread. The **perf ping** and **perf mx** Matter Shell CLI commands send the EmptyCommand to the custom Performance Testing cluster on Endpoint 0 of the destination node. For ping, the command is sent to a destination NodeId and the response is the ping reply. For multicast, the command is sent to a groupId with no response expected. The node issuing commands is the "sender", the node processing the command is the "receiver."
+This example enables Matter performance testing on Silicon Labs EFR32 SoC over Thread. The **perf ping** and **perf mx** Matter Shell CLI commands send the EmptyCommand to the custom Performance Testing cluster on Endpoint 1 of the destination node. For ping, the command is sent to a destination NodeId and the response is the ping reply. For multicast, the command is sent to a groupId with no response expected. The node issuing commands is the "sender", the node processing the command is the "receiver."
 
-The device is commissioned over BLE. Credentials are then provided so the device joins the Thread network. Enable the functionality by installing the Performance Testing Utilities and CLI component and adding the custom Performance Testing cluster (see [Defining a Custom Cluster](https://docs.silabs.com/matter/2.9.0/matter-references/matter-zap#defining-a-custom-cluster)), cluster XML: [`performance-test-cluster.xml`](https://github.com/SiliconLabsSoftware/matter_extension/blob/v2.8.1/slc/apps/performance-test-app/thread/performance-test-cluster.xml). For multicast, enable the Groups cluster server on Endpoint 0 in ZAP.
+The device is commissioned over BLE. Credentials are then provided so the device joins the Thread network. Enable the functionality by installing the Performance Testing Utilities and CLI component and adding the custom Performance Testing cluster (see [Defining a Custom Cluster](https://docs.silabs.com/matter/2.9.0/matter-references/matter-zap#defining-a-custom-cluster)), cluster XML: [`performance-test-cluster.xml`](https://github.com/SiliconLabsSoftware/matter_extension/blob/v2.8.1/slc/apps/performance-test-app/thread/performance-test-cluster.xml). For multicast, enable the Groups cluster server on Endpoint 1 in ZAP.
 
 **Commands:** `perf ping <count> <fabricIndex> <destNodeId> <timeout_ms>`,`perf mx <fabricIndex> <destGroupId> <sequence number>`.
 
@@ -41,8 +41,8 @@ If building the sample application on its own, a bootloader must be flashed sepa
 
 **Enabling the functionality**
 
-- **Simplicity Studio:** Create a Matter over Thread project. Install the Performance Testing Utilities component under _Silicon Labs Matter > Platform_. In ZAP (Configuration Tools > Zigbee Cluster Configurator) enable the Groups cluster server on Endpoint 0 (required for multicast). Add the custom Performance Testing cluster per [Defining a Custom Cluster](https://docs.silabs.com/matter/2.9.0/matter-references/matter-zap#defining-a-custom-cluster), cluster XML: [`performance-test-cluster.xml`](https://github.com/SiliconLabsSoftware/matter_extension/blob/v2.8.1/slc/apps/performance-test-app/thread/performance-test-cluster.xml). Build, the same binary can act as sender and receiver.
-- **SLC CLI:** In a Thread sample app, edit the ZAP file (see project .slcp), set Groups server enabled on the MA-rootdevice endpoint, add the custom Performance Testing cluster as above, then run `slc generate` with `--with "matter_performance_testing"`. The same binary can act as sender and receiver.
+- **Simplicity Studio:** Create a Matter over Thread project. Install the Performance Testing Utilities component under _Silicon Labs Matter > Platform_. In ZAP (Configuration Tools > Zigbee Cluster Configurator) enable the Groups cluster server on Endpoint 1 (required for multicast). Add the custom Performance Testing cluster per [Defining a Custom Cluster](https://docs.silabs.com/matter/2.9.0/matter-references/matter-zap#defining-a-custom-cluster), cluster XML: [`performance-test-cluster.xml`](https://github.com/SiliconLabsSoftware/matter_extension/blob/v2.8.1/slc/apps/performance-test-app/thread/performance-test-cluster.xml). Build, the same binary can act as sender and receiver.
+- **SLC CLI:** In a Thread sample app, edit the ZAP file (see project .slcp), set Groups server enabled on the  endpoint 1, add the custom Performance Testing cluster as above, then run `slc generate` with `--with "matter_performance_testing"`. The same binary can act as sender and receiver.
 
 See [Custom Matter Device Development](https://docs.silabs.com/matter/2.9.0/matter-references/custom-matter-device#custom-matter-device-development) for customization.
 
@@ -50,20 +50,20 @@ See [Custom Matter Device Development](https://docs.silabs.com/matter/2.9.0/matt
 
 1. Build and flash the bootloader and application to your board. The same binary can act as sender and receiver.
 2. Commission sender and receiver to the same Thread network.
-3. **Ping:** On the receiver, add an ACL entry that grants the sender management privileges to Endpoint 0. Example:
+3. **Ping:** On the receiver, add an ACL entry that grants the sender management privileges to Endpoint 1. Example:
    ```shell
-   chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": null, "targets": null}]' <receiverNodeId> 0
+   chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": null, "targets": null}]' <receiverNodeId> 1
    ```
    On the sender, run `perf ping <count> <fabricIndex> <destNodeId> <timeout_ms>`. The sender establishes a CASE session and sends EmptyCommand. When the count is done it prints e.g. "Ping: 44 packets transmitted, 44 packets received." Ping and multicast both print a sequence number to the PTI channel (ping uses 1729).
 4. **Multicast:** Create the same group and group key set on sender and receiver, then add an ACL on the receiver for the group. Example for Group 257 (run on sender then receiver, use your node IDs):
    ```shell
-   chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 42, "groupKeySecurityPolicy": 0, "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000, "epochKey1": "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime1": 2220001, "epochKey2": "d2d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime2": 2220002}' <nodeId> 0
-   chip-tool groupkeymanagement write group-key-map '[{"groupId": 257, "groupKeySetID": 42}]' <nodeId> 0
-   chip-tool groups add-group 257 "GroupName" <nodeId> 0
+   chip-tool groupkeymanagement key-set-write '{"groupKeySetID": 42, "groupKeySecurityPolicy": 0, "epochKey0": "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime0": 2220000, "epochKey1": "d1d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime1": 2220001, "epochKey2": "d2d1d2d3d4d5d6d7d8d9dadbdcdddedf", "epochStartTime2": 2220002}' <nodeId> 1
+   chip-tool groupkeymanagement write group-key-map '[{"groupId": 257, "groupKeySetID": 42}]' <nodeId> 1
+   chip-tool groups add-group 257 "GroupName" <nodeId> 1
    ```
    On the receiver only, add ACL for the group:
    ```shell
-   chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": null, "targets": null},{"fabricIndex": 1, "privilege": 4, "authMode": 3, "subjects": [257], "targets": null}]' <receiverNodeId> 0
+   chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": null, "targets": null},{"fabricIndex": 1, "privilege": 4, "authMode": 3, "subjects": [257], "targets": null}]' <receiverNodeId> 1
    ```
    On the sender, run `perf mx <fabricIndex> <destGroupId> <sequence>`. Multicast sends EmptyCommand to the group address with no response expected.
 
@@ -75,7 +75,7 @@ This app focuses on performance-test CLI commands, button/LED behavior follows t
 
 **Ping or multicast fails**
 - Ensure sender and receiver are on the same fabric and Thread network.
-- For ping, verify the receiver ACL grants the sender management access to Endpoint 0.
+- For ping, verify the receiver ACL grants the sender management access to Endpoint 1.
 - For multicast, verify group key set and group membership match on both nodes and receiver ACL allows the group.
 
 **Commissioning fails**

--- a/slc/apps/performance_test_app/thread/performance-test-app.zap
+++ b/slc/apps/performance_test_app/thread/performance-test-app.zap
@@ -3578,122 +3578,6 @@
               "reportableChange": 0
             }
           ]
-        },
-        {
-          "name": "Performance Testing",
-          "code": 4294048834,
-          "mfgCode": null,
-          "define": "PERFORMANCE_TESTING_CLUSTER",
-          "side": "server",
-          "enabled": 1,
-          "commands": [
-            {
-              "name": "EmptyCommand",
-              "code": 0,
-              "mfgCode": null,
-              "source": "client",
-              "isIncoming": 1,
-              "isEnabled": 1
-            }
-          ],
-          "attributes": [
-            {
-              "name": "GeneratedCommandList",
-              "code": 65528,
-              "mfgCode": null,
-              "side": "server",
-              "type": "array",
-              "included": 1,
-              "storageOption": "External",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "AcceptedCommandList",
-              "code": 65529,
-              "mfgCode": null,
-              "side": "server",
-              "type": "array",
-              "included": 1,
-              "storageOption": "External",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "EventList",
-              "code": 65530,
-              "mfgCode": null,
-              "side": "server",
-              "type": "array",
-              "included": 1,
-              "storageOption": "External",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "AttributeList",
-              "code": 65531,
-              "mfgCode": null,
-              "side": "server",
-              "type": "array",
-              "included": 1,
-              "storageOption": "External",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "FeatureMap",
-              "code": 65532,
-              "mfgCode": null,
-              "side": "server",
-              "type": "bitmap32",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "0",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            },
-            {
-              "name": "ClusterRevision",
-              "code": 65533,
-              "mfgCode": null,
-              "side": "server",
-              "type": "int16u",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "1",
-              "reportable": 1,
-              "minInterval": 1,
-              "maxInterval": 65534,
-              "reportableChange": 0
-            }
-          ]
         }
       ]
     },
@@ -5581,6 +5465,122 @@
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
+              "reportableChange": 0
+            }
+          ]
+        },
+        {
+          "name": "Performance Testing",
+          "code": 4294048834,
+          "mfgCode": null,
+          "define": "PERFORMANCE_TESTING_CLUSTER",
+          "side": "server",
+          "enabled": 1,
+          "commands": [
+            {
+              "name": "EmptyCommand",
+              "code": 0,
+              "mfgCode": null,
+              "source": "client",
+              "isIncoming": 1,
+              "isEnabled": 1
+            }
+          ],
+          "attributes": [
+            {
+              "name": "GeneratedCommandList",
+              "code": 65528,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AcceptedCommandList",
+              "code": 65529,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "EventList",
+              "code": 65530,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "AttributeList",
+              "code": 65531,
+              "mfgCode": null,
+              "side": "server",
+              "type": "array",
+              "included": 1,
+              "storageOption": "External",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "FeatureMap",
+              "code": 65532,
+              "mfgCode": null,
+              "side": "server",
+              "type": "bitmap32",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "0",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
+              "reportableChange": 0
+            },
+            {
+              "name": "ClusterRevision",
+              "code": 65533,
+              "mfgCode": null,
+              "side": "server",
+              "type": "int16u",
+              "included": 1,
+              "storageOption": "RAM",
+              "singleton": 0,
+              "bounded": 0,
+              "defaultValue": "1",
+              "reportable": 1,
+              "minInterval": 1,
+              "maxInterval": 65534,
               "reportableChange": 0
             }
           ]


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
https://jira.silabs.com/browse/MATTER-6495

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Performance testing broken due to remove groups support on ep0

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
In the performance-test-app move the Performance Testing cluster to End Point 1. Update the perf ping command to use endpoint 0, update the README.  

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Verified that "perf mx 0 1 1 1" completes without a problem after a group has been added to endpoint 1