### PR TITLE
[MATTER-6352] Remove use of rail_mux_aux component

### DIFF
--- a/slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_freertos.slcp
+++ b/slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_freertos.slcp
@@ -9,7 +9,6 @@ component:
   - id: device_init
   - id: clock_manager
   - id: rail_mux
-  - id: rail_mux_aux
   - id: sl_main
   # Needed to use Network Analyser
   #- id: rail_util_pti
@@ -183,11 +182,11 @@ configuration:
     value: 16
   - name: SL_MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS
     value: 1
-# Additional config when using ot_coap_cert_libs
+  # Additional config when using ot_coap_cert_libs
   - name: SL_MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
     value: 1
     condition: [ot_coap_cert_libs]
-# series 3 requires more stack in zb stacks
+  # series 3 requires more stack in zb stacks
   - name: SL_CLI_EXAMPLE_TASK_STACK_SIZE
     value: 1500
     condition:

--- a/slc/component/matter-core-sdk/zigbee_debug.slcc
+++ b/slc/component/matter-core-sdk/zigbee_debug.slcc
@@ -13,7 +13,6 @@ requires:
   - name: zigbee_debug_print
   - name: zigbee_zcl_cli
   - name: zigbee_core_cli
-  - name: rail_mux_aux
 provides:
   - name: matter_zigbee_debug
 define:


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
MATTER-6352

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
During early sisdk 2026.6 drops, `rail_mux_aux` was not properly gated and was required to complete a build.
`rail_mux_aux` is not needed by our apps and is still in evaluation quality. 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
`rail_mux_aux` dependencies have been fixed within the sisdk.
Remove `rail_mux_aux` from our slcc and slcps at the matter/cmp layer.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Validate compilation of CMP apps.
Commission CMP light on Series 3 and validate controls.