### PR TITLE
[MATTER-6594] Fix conditional require of matter_syscall_stubs for MG platform

### DIFF
--- a/slc/component/matter.slcc
+++ b/slc/component/matter.slcc
@@ -59,7 +59,7 @@ toolchain_settings:
     value: "-femulated-tls"
   - option: llvm_linker_option
     value: "--rtlib=compiler-rt"
-    
+
 provides:
   - name: matter
 define:
@@ -120,7 +120,7 @@ requires:
   - name: matter_ot_mbedtls_override
   - name: matter_server_cluster
   - name: matter_syscall_stubs
-    unless: [matter_platform_siwx917]
+    condition: [matter_efr32]
   - name: matter_nlassert
   - name: matter_nlio
   - name: matter_includes
@@ -132,7 +132,7 @@ requires:
   - name: matter_codegen_data_model_sources
     condition: [matter_codegen_dm]
   - name: matter_code_driven_data_model_sources
-    condition: [matter_code_driven_dm]  
+    condition: [matter_code_driven_dm]
   - name: matter_data_model
   - name: matter_data_model_provider
   - name: matter_encode_decode


### PR DESCRIPTION
<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
[MATTER-6594](https://jira.silabs.com/browse/MATTER-6594)

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Some Zigbee logs/CLI outputs are missing in CMP builds.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
`unless :` doesn't work in `require :`  sections, We have to used condition.
The closest opposite condition of the existing `unless matter_platform_siwx917 `would be `matter_platform_mg` but that component is used in NCPs build. 
Using condition: [matter_efr32] works for EFR32MG (S2) and SIMG (S3). 
Another option would be `matter_thread`

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Build cmp app with new condition on `matter_syscall_stubs` require.
Confirm zb cli plugin outputs

```
matterCli> silabs info                                             
MFG String: (deprecated)
AppBuilder MFG Code: 0x1049
node [(>)C02CEDFFFE94AAAC] chan [11] pwr [3]                       
panID [0x383C] nodeID [0x0002] xpan [0x(>)BC37DE78F616753E]        
parentID [0xFFFE] parentRssi [0]                                   
stack ver. [9.1.0 GA build 0]                                      
nodeType [0x02]                                                    
Security level [05]                                                
network state [02] Buffer bytes: 8192 / 8192                       
Ep cnt: 1                                                          
ep 1 [endpoint enabled, device enabled] nwk [0] profile [0x0104] devId [0x0101] ver [0x03]
    in (server) cluster: 0x0000 (Basic)                                
    in (server) cluster: 0x0003 (Identify)
    in (server) cluster: 0x0004 (Groups)                               
    in (server) cluster: 0x0005 (Scenes)
    in (server) cluster: 0x0006 (On/off)                               
    in (server) cluster: 0x0008 (Level Control)                        
    out(client) cluster: 0x0019 (Over the Air Bootloading)
    out(client) cluster: 0x0406 (Occupancy Sensing)                    
    in (server) cluster: 0x1000 (ZLL Commissioning)                
Nwk cnt: 1
nwk 0 [Primary (pro)]                                                
    nodeType [0x01]                                                    
    securityProfile [0x05]                                           
RTOS [FreeRTOS]                                                    
Done
```