### PR TITLE
Revert "MATTER-6593: Added BRD4343C Support (#788)"

### DIFF
--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -26,7 +26,7 @@
     "full": {
         "default": [
             {
-                "boards": ["brd4338a", "brd2605a", "brd4343a", "brd4342a", "brd2708a", "brd2911a", "brd4343c"],
+                "boards": ["brd4338a", "brd2605a", "brd4343a", "brd4342a", "brd2708a", "brd2911a"],
                 "arguments": [""]
             },
             {

--- a/board_compatibility_matrix.html
+++ b/board_compatibility_matrix.html
@@ -32,11 +32,11 @@ body { display: inline-block; margin: 0; }
 <p>Total number of boards in each category</p>
 <table>
   <tr>
-    <td class='compatible'>575</td>
+    <td class='compatible'>558</td>
     <td>Compatible</td>
   </tr>
   <tr>
-    <td class='incompatible'>1675</td>
+    <td class='incompatible'>1617</td>
     <td>Incompatible</td>
   </tr>
 </table>
@@ -71,7 +71,6 @@ body { display: inline-block; margin: 0; }
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4338A' target='_blank'>brd4338a</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4342A' target='_blank'>brd4342a</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4343A' target='_blank'>brd4343a</a></th>
-    <th><a href='http://hwtbase.silabs.com/products/boards/BRD4343C' target='_blank'>brd4343c</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4350A' target='_blank'>brd4350a</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4351A' target='_blank'>brd4351a</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4407A' target='_blank'>brd4407a</a></th>
@@ -82,7 +81,6 @@ body { display: inline-block; margin: 0; }
   <tr>
     <td class='first-column' title='matter_bootloader_internal_series_3'>Matter - SoC Bootloader Internal Storage Series 3</td>
     <td class='compatible'>1</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -115,7 +113,6 @@ body { display: inline-block; margin: 0; }
   <tr>
     <td class='first-column' title='matter_thread_soc_air_quality_sensor_app_series_2_freertos'>Matter Thread - SoC Air Quality Sensor with external Bootloader FreeRTOS</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
@@ -147,7 +144,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_air_quality_sensor_app_series_2_internal_freertos'>Matter Thread - SoC Air Quality Sensor with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -188,7 +184,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -213,7 +208,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_closure_app_series_2_freertos'>Matter Thread - SoC Closure with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -250,7 +244,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -280,7 +273,6 @@ body { display: inline-block; margin: 0; }
   <tr>
     <td class='first-column' title='matter_thread_soc_closure_app_series_3_freertos'>Matter Thread - SoC Closure with internal Bootloader FreeRTOS</td>
     <td class='compatible'>1</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -341,11 +333,9 @@ body { display: inline-block; margin: 0; }
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
-    <td class='compatible'>1</td>
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_dishwasher_app_series_2_freertos'>Matter Thread - SoC Dishwasher with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -378,7 +368,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_dishwasher_app_series_2_internal_freertos'>Matter Thread - SoC Dishwasher with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -419,7 +408,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -444,7 +432,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_evse_app_series_2_freertos'>Matter Thread - SoC EVSE with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -477,7 +464,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_evse_app_series_2_internal_freertos'>Matter Thread - SoC EVSE with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -518,7 +504,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -543,7 +528,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_fan_control_app_series_2_freertos'>Matter Thread - SoC Fan Control with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -576,7 +560,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_fan_control_app_series_2_internal_freertos'>Matter Thread - SoC Fan Control with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -617,7 +600,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -642,7 +624,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_light_switch_app_series_2_freertos'>Matter Thread - SoC Light Switch with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -675,7 +656,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_light_switch_app_series_2_internal_freertos'>Matter Thread - SoC Light Switch with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -716,7 +696,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -741,7 +720,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lighting_app_series_2_freertos'>Matter Thread - SoC Lighting with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -774,7 +752,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lighting_app_series_2_internal_freertos'>Matter Thread - SoC Lighting with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -815,7 +792,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -840,7 +816,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lighting_app_trustzone_series_2_freertos'>Matter Thread - SoC Lighting TrustZone with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -881,7 +856,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -906,7 +880,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lock_app_series_2_freertos'>Matter Thread - SoC Lock with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -939,7 +912,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lock_app_series_2_internal_freertos'>Matter Thread - SoC Lock with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -980,7 +952,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1005,7 +976,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_multi_sensor_app_series_2_freertos'>Matter Thread - SoC Multi Sensor with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1038,7 +1008,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_multi_sensor_app_series_2_internal_freertos'>Matter Thread - SoC Multi Sensor with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1079,7 +1048,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1104,7 +1072,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_onoff_plug_app_series_2_freertos'>Matter Thread - SoC Onoff Plug with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1137,7 +1104,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_onoff_plug_app_series_2_internal_freertos'>Matter Thread - SoC Onoff Plug with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1178,7 +1144,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1203,7 +1168,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_performance_test_app_series_2_freertos'>Matter Thread - SoC Performance Test with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1236,7 +1200,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_performance_test_app_series_2_internal_freertos'>Matter Thread - SoC Performance Test with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1277,7 +1240,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1302,7 +1264,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_platform_template_series_2_freertos'>Matter Thread - SoC Platform Template with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1335,7 +1296,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_platform_template_series_2_internal_freertos'>Matter Thread - SoC Platform Template with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1376,7 +1336,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1401,7 +1360,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_rangehood_app_series_2_freertos'>Matter Thread - SoC Rangehood with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1434,7 +1392,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_rangehood_app_series_2_internal_freertos'>Matter Thread - SoC Rangehood with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1475,7 +1432,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1500,7 +1456,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_refrigerator_app_series_2_freertos'>Matter Thread - SoC Refrigerator with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1533,7 +1488,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_refrigerator_app_series_2_internal_freertos'>Matter Thread - SoC Refrigerator with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1574,7 +1528,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1599,7 +1552,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_thermostat_series_2_freertos'>Matter Thread - SoC Thermostat with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1632,7 +1584,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_thermostat_series_2_internal_freertos'>Matter Thread - SoC Thermostat with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1673,7 +1624,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1698,7 +1648,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_window_app_series_2_freertos'>Matter Thread - SoC Window App with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1731,7 +1680,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_window_app_series_2_internal_freertos'>Matter Thread - SoC Window App with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1772,7 +1720,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1797,7 +1744,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_zigbee_light_series_2_freertos'>Matter Thread - SoC Zigbee Light with external Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1830,7 +1776,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_zigbee_light_series_2_internal_freertos'>Matter Thread - SoC Zigbee Light with internal Bootloader FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1871,7 +1816,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1896,7 +1840,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_wifi_917_ncp_fan_control_app_freertos'>Matter WiFi - 917 NCP Fan Control FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1933,7 +1876,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1962,7 +1904,6 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_wifi_917_ncp_thermostat_freertos'>Matter WiFi - 917 NCP Thermostat FreeRTOS</td>
-    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1999,7 +1940,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -2030,7 +1970,6 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_air_quality_sensor_app_freertos'>Matter WiFi - SoC Air Quality Sensor FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2064,7 +2003,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
-    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2096,7 +2034,6 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_dishwasher_app_freertos'>Matter WiFi - SoC Dishwasher FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2130,7 +2067,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
-    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2162,7 +2098,6 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_fan_control_app_freertos'>Matter WiFi - SoC Fan Control FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2196,7 +2131,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
-    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2228,7 +2162,6 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_lighting_app_freertos'>Matter WiFi - SoC Lighting FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2262,7 +2195,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
-    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2294,7 +2226,6 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_multi_sensor_app_freertos'>Matter WiFi - SoC Multi Sensor FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2328,7 +2259,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
-    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2360,7 +2290,6 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_oven_app_freertos'>Matter WiFi - SoC Oven FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2394,7 +2323,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
-    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2426,7 +2354,6 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_rangehood_app_freertos'>Matter WiFi - SoC Rangehood FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2460,7 +2387,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
-    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2493,7 +2419,6 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
-    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2525,7 +2450,6 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_window_app_freertos'>Matter WiFi - SoC Window App FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
-    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>

--- a/matter_demos.xml
+++ b/matter_demos.xml
@@ -290,16 +290,6 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_air_quality_sensor_app_freertos" label="Matter WiFi - SoC Air Quality Sensor FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi air quality sensor app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Air Quality Sensor FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_air_quality_sensor_app_freertos_solution/artifact/matter_wifi_soc_air_quality_sensor_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/air_quality_sensor_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_closure_app_series_2_freertos" label="Matter Thread - SoC Closure with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread closure app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Closure with external Bootloader FreeRTOS app"/>
@@ -590,16 +580,6 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_closure_app_freertos" label="Matter WiFi - SoC Closure FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi closure app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Closure FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_closure_app_freertos_solution/artifact/matter_wifi_soc_closure_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/closure_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_evse_app_series_2_freertos" label="Matter Thread - SoC EVSE with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread EVSE app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC EVSE with external Bootloader FreeRTOS app"/>
@@ -886,16 +866,6 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343a/matter_wifi_soc_evse_app_freertos_solution/artifact/matter_wifi_soc_evse_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/evse_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_evse_app_freertos" label="Matter WiFi - SoC EVSE FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi EVSE app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC EVSE FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_evse_app_freertos_solution/artifact/matter_wifi_soc_evse_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/evse_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -1230,16 +1200,6 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_fan_control_app_freertos" label="Matter WiFi - SoC Fan Control FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi fan control app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Fan Control FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_fan_control_app_freertos_solution/artifact/matter_wifi_soc_fan_control_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/fan_control_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_light_switch_app_series_2_freertos" label="Matter Thread - SoC Light Switch with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread light switch app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Light Switch with external Bootloader FreeRTOS app"/>
@@ -1526,16 +1486,6 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343a/matter_wifi_soc_light_switch_app_freertos_solution/artifact/matter_wifi_soc_light_switch_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/light_switch_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_light_switch_app_freertos" label="Matter WiFi - SoC Light Switch FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi light switch app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Light Switch FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_light_switch_app_freertos_solution/artifact/matter_wifi_soc_light_switch_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/light_switch_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -1846,16 +1796,6 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343a/matter_wifi_soc_lighting_app_freertos_solution/artifact/matter_wifi_soc_lighting_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/lighting_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_lighting_app_freertos" label="Matter WiFi - SoC Lighting FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi lighting app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Lighting FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_lighting_app_freertos_solution/artifact/matter_wifi_soc_lighting_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/lighting_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -2190,16 +2130,6 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_lock_app_freertos" label="Matter WiFi - SoC Lock FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi door lock app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Lock FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_lock_app_freertos_solution/artifact/matter_wifi_soc_lock_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/lock_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_multi_sensor_app_series_2_freertos" label="Matter Thread - SoC Multi Sensor with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread multi-sensor app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Multi Sensor with external Bootloader FreeRTOS app"/>
@@ -2486,16 +2416,6 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343a/matter_wifi_soc_multi_sensor_app_freertos_solution/artifact/matter_wifi_soc_multi_sensor_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/multi_sensor_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_multi_sensor_app_freertos" label="Matter WiFi - SoC Multi Sensor FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi multi-sensor app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Multi Sensor FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_multi_sensor_app_freertos_solution/artifact/matter_wifi_soc_multi_sensor_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/multi_sensor_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -2790,16 +2710,6 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_onoff_plug_app_freertos" label="Matter WiFi - SoC Onoff Plug FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi on/off plug app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Onoff Plug FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_onoff_plug_app_freertos_solution/artifact/matter_wifi_soc_onoff_plug_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/onoff_plug_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
   <demo name="brd2605a.demo.matter_wifi_soc_oven_app_freertos" label="Matter WiFi - SoC Oven FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi oven app</model:description>
     <property key="demos.blurb" value="Matter WiFi - SoC Oven FreeRTOS app"/>
@@ -2856,16 +2766,6 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343a/matter_wifi_soc_oven_app_freertos_solution/artifact/matter_wifi_soc_oven_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/oven_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_oven_app_freertos" label="Matter WiFi - SoC Oven FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi oven app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Oven FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_oven_app_freertos_solution/artifact/matter_wifi_soc_oven_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/oven_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -3160,16 +3060,6 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_platform_template_freertos" label="Matter WiFi - SoC Platform Template FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi platform template app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Platform Template FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_platform_template_freertos_solution/artifact/matter_wifi_soc_platform_template_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/platform_template/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_rangehood_app_series_2_freertos" label="Matter Thread - SoC Rangehood with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread rangehood app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Rangehood with external Bootloader FreeRTOS app"/>
@@ -3460,16 +3350,6 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_rangehood_app_freertos" label="Matter WiFi - SoC Rangehood FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi rangehood app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Rangehood FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_rangehood_app_freertos_solution/artifact/matter_wifi_soc_rangehood_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/rangehood_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_refrigerator_app_series_2_freertos" label="Matter Thread - SoC Refrigerator with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread refrigerator app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Refrigerator with external Bootloader FreeRTOS app"/>
@@ -3756,16 +3636,6 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343a/matter_wifi_soc_refrigerator_app_freertos_solution/artifact/matter_wifi_soc_refrigerator_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/refrigerator_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_refrigerator_app_freertos" label="Matter WiFi - SoC Refrigerator FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi refrigerator app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Refrigerator FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_refrigerator_app_freertos_solution/artifact/matter_wifi_soc_refrigerator_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/refrigerator_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -4160,16 +4030,6 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_thermostat_freertos" label="Matter WiFi - SoC Thermostat FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi thermostat app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Thermostat FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_thermostat_freertos_solution/artifact/matter_wifi_soc_thermostat_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/thermostat/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_window_app_series_2_freertos" label="Matter Thread - SoC Window App with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread window covering app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Window App with external Bootloader FreeRTOS app"/>
@@ -4496,16 +4356,6 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343a/matter_wifi_soc_window_app_freertos_solution/artifact/matter_wifi_soc_window_app_freertos.rps"/>
-    <property key="core.readmeFiles" value="slc/apps/window_app/wifi/README.md"/>
-    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
-    <property key="core.quality" value="PRODUCTION"/>
-  </demo>
-  <demo name="brd4343c.demo.matter_wifi_soc_window_app_freertos" label="Matter WiFi - SoC Window App FreeRTOS">
-    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi window covering app</model:description>
-    <property key="demos.blurb" value="Matter WiFi - SoC Window App FreeRTOS app"/>
-    <property key="core.partCompatibility" value=".*"/>
-    <property key="core.boardCompatibility" value="brd4343c"/>
-    <property key="demos.imageFile" value="asset://extension.matter_2.8.1/demos/brd4343c/matter_wifi_soc_window_app_freertos_solution/artifact/matter_wifi_soc_window_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/window_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>

--- a/matter_docs.xml
+++ b/matter_docs.xml
@@ -4,7 +4,7 @@
     <property key="core.category" value="Release Notes"/>
     <property key="core.priority" value="40"/>
     <property key="core.boardCompatibility" value="brd4116a brd4117a brd4118a brd4120a brd4121a brd4186c brd4187c brd2703a brd2704a brd2601b
-                brd2608a brd4316a brd4317a brd4319a brd4337a brd4318a brd1019a brd4350a brd4351a brd2709a brd2719a brd4407a brd4408a brd4338a brd4342a brd4343a brd4343c brd2605a brd2708a brd2911a"/>
+                brd2608a brd4316a brd4317a brd4319a brd4337a brd4318a brd1019a brd4350a brd4351a brd2709a brd2719a brd4407a brd4408a brd4338a brd4342a brd4343a brd2605a brd2708a brd2911a"/>
     <property key="core.partCompatibility" value=".*efr32mg26.* .*efr32mg24.* .*mgm24.* .*mgm26.* .*simg301.* .*si917.* .*siwg917.* "/>
     <property key="core.sdkAndProtocolTags" value="Matter"/>
     <description>Release Notes for the Silicon Labs Matter v2.8.1-1.5. These release notes provide information on the release including part compatibility, changes and added/deleted/deprecated features/API.</description>

--- a/matter_templates.xml
+++ b/matter_templates.xml
@@ -70,7 +70,7 @@
     <properties key="solutionReferenceId" value="slc.apps.air_quality_sensor_app.wifi.matter_wifi_soc_air_quality_sensor_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/air_quality_sensor_app/wifi/matter_wifi_soc_air_quality_sensor_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/air_quality_sensor_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -86,7 +86,7 @@
     <properties key="solutionReferenceId" value="slc.apps.air_quality_sensor_app.wifi.matter_wifi_soc_air_quality_sensor_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/air_quality_sensor_app/wifi/matter_wifi_soc_air_quality_sensor_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/air_quality_sensor_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -214,7 +214,7 @@
     <properties key="solutionReferenceId" value="slc.apps.closure_app.wifi.matter_wifi_soc_closure_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/closure_app/wifi/matter_wifi_soc_closure_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/closure_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -230,7 +230,7 @@
     <properties key="solutionReferenceId" value="slc.apps.closure_app.wifi.matter_wifi_soc_closure_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/closure_app/wifi/matter_wifi_soc_closure_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/closure_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -310,7 +310,7 @@
     <properties key="solutionReferenceId" value="slc.apps.evse_app.wifi.matter_wifi_soc_evse_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/evse_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -326,7 +326,7 @@
     <properties key="solutionReferenceId" value="slc.apps.evse_app.wifi.matter_wifi_soc_evse_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/evse_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -438,7 +438,7 @@
     <properties key="solutionReferenceId" value="slc.apps.fan_control_app.wifi.matter_wifi_soc_fan_control_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/fan_control_app/wifi/matter_wifi_soc_fan_control_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/fan_control_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -454,7 +454,7 @@
     <properties key="solutionReferenceId" value="slc.apps.fan_control_app.wifi.matter_wifi_soc_fan_control_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/fan_control_app/wifi/matter_wifi_soc_fan_control_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/fan_control_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -534,7 +534,7 @@
     <properties key="solutionReferenceId" value="slc.apps.light_switch_app.wifi.matter_wifi_soc_light_switch_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/light_switch_app/wifi/matter_wifi_soc_light_switch_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/light_switch_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -550,7 +550,7 @@
     <properties key="solutionReferenceId" value="slc.apps.light_switch_app.wifi.matter_wifi_soc_light_switch_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/light_switch_app/wifi/matter_wifi_soc_light_switch_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/light_switch_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -662,7 +662,7 @@
     <properties key="solutionReferenceId" value="slc.apps.lighting_app.wifi.matter_wifi_soc_lighting_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/lighting_app/wifi/matter_wifi_soc_lighting_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/lighting_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -678,7 +678,7 @@
     <properties key="solutionReferenceId" value="slc.apps.lighting_app.wifi.matter_wifi_soc_lighting_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/lighting_app/wifi/matter_wifi_soc_lighting_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/lighting_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -790,7 +790,7 @@
     <properties key="solutionReferenceId" value="slc.apps.lock_app.wifi.matter_wifi_soc_lock_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/lock_app/wifi/matter_wifi_soc_lock_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/lock_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -806,7 +806,7 @@
     <properties key="solutionReferenceId" value="slc.apps.lock_app.wifi.matter_wifi_soc_lock_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/lock_app/wifi/matter_wifi_soc_lock_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/lock_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -886,7 +886,7 @@
     <properties key="solutionReferenceId" value="slc.apps.multi_sensor_app.wifi.matter_wifi_soc_multi_sensor_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/multi_sensor_app/wifi/matter_wifi_soc_multi_sensor_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/multi_sensor_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -902,7 +902,7 @@
     <properties key="solutionReferenceId" value="slc.apps.multi_sensor_app.wifi.matter_wifi_soc_multi_sensor_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/multi_sensor_app/wifi/matter_wifi_soc_multi_sensor_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/multi_sensor_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -982,7 +982,7 @@
     <properties key="solutionReferenceId" value="slc.apps.onoff_plug_app.wifi.matter_wifi_soc_onoff_plug_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/onoff_plug_app/wifi/matter_wifi_soc_onoff_plug_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/onoff_plug_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -998,7 +998,7 @@
     <properties key="solutionReferenceId" value="slc.apps.onoff_plug_app.wifi.matter_wifi_soc_onoff_plug_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/onoff_plug_app/wifi/matter_wifi_soc_onoff_plug_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/onoff_plug_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1029,7 +1029,7 @@
     <properties key="solutionReferenceId" value="slc.apps.oven_app.wifi.matter_wifi_soc_oven_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/oven_app/wifi/matter_wifi_soc_oven_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/oven_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1045,7 +1045,7 @@
     <properties key="solutionReferenceId" value="slc.apps.oven_app.wifi.matter_wifi_soc_oven_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/oven_app/wifi/matter_wifi_soc_oven_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/oven_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1125,7 +1125,7 @@
     <properties key="solutionReferenceId" value="slc.apps.platform_template.wifi.matter_wifi_soc_platform_template_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/platform_template/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1141,7 +1141,7 @@
     <properties key="solutionReferenceId" value="slc.apps.platform_template.wifi.matter_wifi_soc_platform_template_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/platform_template/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1221,7 +1221,7 @@
     <properties key="solutionReferenceId" value="slc.apps.rangehood_app.wifi.matter_wifi_soc_rangehood_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/rangehood_app/wifi/matter_wifi_soc_rangehood_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/rangehood_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1237,7 +1237,7 @@
     <properties key="solutionReferenceId" value="slc.apps.rangehood_app.wifi.matter_wifi_soc_rangehood_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/rangehood_app/wifi/matter_wifi_soc_rangehood_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/rangehood_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1317,7 +1317,7 @@
     <properties key="solutionReferenceId" value="slc.apps.refrigerator_app.wifi.matter_wifi_soc_refrigerator_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/refrigerator_app/wifi/matter_wifi_soc_refrigerator_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/refrigerator_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1333,7 +1333,7 @@
     <properties key="solutionReferenceId" value="slc.apps.refrigerator_app.wifi.matter_wifi_soc_refrigerator_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/refrigerator_app/wifi/matter_wifi_soc_refrigerator_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/refrigerator_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1445,7 +1445,7 @@
     <properties key="solutionReferenceId" value="slc.apps.thermostat.wifi.matter_wifi_soc_thermostat_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/thermostat/wifi/matter_wifi_soc_thermostat_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/thermostat/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1461,7 +1461,7 @@
     <properties key="solutionReferenceId" value="slc.apps.thermostat.wifi.matter_wifi_soc_thermostat_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/thermostat/wifi/matter_wifi_soc_thermostat_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/thermostat/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1573,7 +1573,7 @@
     <properties key="solutionReferenceId" value="slc.apps.window_app.wifi.matter_wifi_soc_window_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/window_app/wifi/matter_wifi_soc_window_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/window_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1589,7 +1589,7 @@
     <properties key="solutionReferenceId" value="slc.apps.window_app.wifi.matter_wifi_soc_window_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/window_app/wifi/matter_wifi_soc_window_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/window_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>

--- a/slc/component/matter-platform/display/matter_default_lcd_config.slcc
+++ b/slc/component/matter-platform/display/matter_default_lcd_config.slcc
@@ -26,9 +26,6 @@ requires:
   - name: matter_lcd_917SOC
     condition:
       - brd4343a
-  - name: matter_lcd_917SOC
-    condition:
-      - brd4343c
 
 # Keep this requirement under matter_lcd_917SOC's
   - name: matter_qr_code

--- a/slc/component/matter-platform/wstk-leds/matter_leds.slcc
+++ b/slc/component/matter-platform/wstk-leds/matter_leds.slcc
@@ -70,10 +70,6 @@ define:
   - name: ENABLE_WSTK_LEDS
     value: "1"
     condition:
-      - brd4343c
-  - name: ENABLE_WSTK_LEDS
-    value: "1"
-    condition:
       - brd4350a
   - name: ENABLE_WSTK_LEDS
     value: "1"

--- a/slc/script/hwfilter-config.yml
+++ b/slc/script/hwfilter-config.yml
@@ -47,7 +47,6 @@ board_allowlist:
     - brd4338a
     - brd4342a
     - brd4343a
-    - brd4343c
     - brd4350a
     - brd4351a
     - brd4407a


### PR DESCRIPTION
This reverts commit 4bfc62e416f22a28932f584ca98326f5a9097de4.

<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
BRD4343C is not available in 4.0.1 hence the build is failing

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Reverting the #788  which added this


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI