### PR TITLE
MATTER-6593: Added BRD4343C Support

### DIFF
--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -26,7 +26,7 @@
     "full": {
         "default": [
             {
-                "boards": ["brd4338a", "brd2605a", "brd4343a", "brd4342a", "brd2708a", "brd2911a"],
+                "boards": ["brd4338a", "brd2605a", "brd4343a", "brd4342a", "brd2708a", "brd2911a", "brd4343c"],
                 "arguments": [""]
             },
             {

--- a/board_compatibility_matrix.html
+++ b/board_compatibility_matrix.html
@@ -32,11 +32,11 @@ body { display: inline-block; margin: 0; }
 <p>Total number of boards in each category</p>
 <table>
   <tr>
-    <td class='compatible'>574</td>
+    <td class='compatible'>591</td>
     <td>Compatible</td>
   </tr>
   <tr>
-    <td class='incompatible'>1659</td>
+    <td class='incompatible'>1719</td>
     <td>Incompatible</td>
   </tr>
 </table>
@@ -71,6 +71,7 @@ body { display: inline-block; margin: 0; }
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4338A' target='_blank'>brd4338a</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4342A' target='_blank'>brd4342a</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4343A' target='_blank'>brd4343a</a></th>
+    <th><a href='http://hwtbase.silabs.com/products/boards/BRD4343C' target='_blank'>brd4343c</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4350A' target='_blank'>brd4350a</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4351A' target='_blank'>brd4351a</a></th>
     <th><a href='http://hwtbase.silabs.com/products/boards/BRD4407A' target='_blank'>brd4407a</a></th>
@@ -81,6 +82,7 @@ body { display: inline-block; margin: 0; }
   <tr>
     <td class='first-column' title='matter_bootloader_internal_series_3'>Matter - SoC Bootloader Internal Storage Series 3</td>
     <td class='compatible'>1</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -113,6 +115,7 @@ body { display: inline-block; margin: 0; }
   <tr>
     <td class='first-column' title='matter_thread_soc_air_quality_sensor_app_series_2_freertos'>Matter Thread - SoC Air Quality Sensor with external Bootloader FreeRTOS</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
@@ -144,6 +147,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_air_quality_sensor_app_series_2_internal_freertos'>Matter Thread - SoC Air Quality Sensor with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -184,6 +188,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -208,6 +213,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_closure_app_series_2_freertos'>Matter Thread - SoC Closure with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -244,6 +250,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -273,6 +280,7 @@ body { display: inline-block; margin: 0; }
   <tr>
     <td class='first-column' title='matter_thread_soc_closure_app_series_3_freertos'>Matter Thread - SoC Closure with internal Bootloader FreeRTOS</td>
     <td class='compatible'>1</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -333,9 +341,11 @@ body { display: inline-block; margin: 0; }
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
+    <td class='compatible'>1</td>
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_dishwasher_app_series_2_freertos'>Matter Thread - SoC Dishwasher with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -368,6 +378,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_dishwasher_app_series_2_internal_freertos'>Matter Thread - SoC Dishwasher with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -408,6 +419,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -432,6 +444,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_evse_app_series_2_freertos'>Matter Thread - SoC EVSE with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -464,6 +477,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_evse_app_series_2_internal_freertos'>Matter Thread - SoC EVSE with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -504,6 +518,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -528,6 +543,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_fan_control_app_series_2_freertos'>Matter Thread - SoC Fan Control with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -560,6 +576,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_fan_control_app_series_2_internal_freertos'>Matter Thread - SoC Fan Control with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -600,6 +617,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -624,6 +642,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_light_switch_app_series_2_freertos'>Matter Thread - SoC Light Switch with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -656,6 +675,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_light_switch_app_series_2_internal_freertos'>Matter Thread - SoC Light Switch with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -696,6 +716,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -720,6 +741,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lighting_app_series_2_freertos'>Matter Thread - SoC Lighting with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -752,6 +774,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lighting_app_series_2_internal_freertos'>Matter Thread - SoC Lighting with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -792,6 +815,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -816,6 +840,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lighting_app_trustzone_series_2_freertos'>Matter Thread - SoC Lighting TrustZone with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -856,6 +881,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -880,6 +906,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lock_app_series_2_freertos'>Matter Thread - SoC Lock with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -912,6 +939,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_lock_app_series_2_internal_freertos'>Matter Thread - SoC Lock with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -952,6 +980,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -976,6 +1005,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_multi_sensor_app_series_2_freertos'>Matter Thread - SoC Multi Sensor with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1008,6 +1038,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_multi_sensor_app_series_2_internal_freertos'>Matter Thread - SoC Multi Sensor with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1048,6 +1079,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1072,6 +1104,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_onoff_plug_app_series_2_freertos'>Matter Thread - SoC Onoff Plug with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1104,6 +1137,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_onoff_plug_app_series_2_internal_freertos'>Matter Thread - SoC Onoff Plug with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1144,6 +1178,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1168,6 +1203,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_performance_test_app_series_2_freertos'>Matter Thread - SoC Performance Test with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1200,6 +1236,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_performance_test_app_series_2_internal_freertos'>Matter Thread - SoC Performance Test with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1240,6 +1277,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1264,6 +1302,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_platform_template_series_2_freertos'>Matter Thread - SoC Platform Template with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1296,6 +1335,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_platform_template_series_2_internal_freertos'>Matter Thread - SoC Platform Template with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1336,6 +1376,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1360,6 +1401,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_rangehood_app_series_2_freertos'>Matter Thread - SoC Rangehood with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1392,6 +1434,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_rangehood_app_series_2_internal_freertos'>Matter Thread - SoC Rangehood with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1432,6 +1475,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1456,6 +1500,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_refrigerator_app_series_2_freertos'>Matter Thread - SoC Refrigerator with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1488,6 +1533,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_refrigerator_app_series_2_internal_freertos'>Matter Thread - SoC Refrigerator with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1528,6 +1574,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1552,6 +1599,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_thermostat_series_2_freertos'>Matter Thread - SoC Thermostat with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1584,6 +1632,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_thermostat_series_2_internal_freertos'>Matter Thread - SoC Thermostat with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1624,6 +1673,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1648,6 +1698,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_wake_on_matter_series_2_freertos'>Matter Thread - SoC Wake on Matter with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1681,6 +1732,7 @@ body { display: inline-block; margin: 0; }
   <tr>
     <td class='first-column' title='matter_thread_soc_window_app_series_2_freertos'>Matter Thread - SoC Window App with external Bootloader FreeRTOS</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
@@ -1712,6 +1764,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_window_app_series_2_internal_freertos'>Matter Thread - SoC Window App with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1752,6 +1805,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1776,6 +1830,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_zigbee_light_series_2_freertos'>Matter Thread - SoC Zigbee Light with external Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1808,6 +1863,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_thread_soc_zigbee_light_series_2_internal_freertos'>Matter Thread - SoC Zigbee Light with internal Bootloader FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1848,6 +1904,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1872,6 +1929,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_wifi_917_ncp_fan_control_app_freertos'>Matter WiFi - 917 NCP Fan Control FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1908,6 +1966,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -1936,6 +1995,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_wifi_917_ncp_lock_app_freertos'>Matter WiFi - 917 NCP Lock FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -1972,6 +2032,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
@@ -2000,6 +2061,7 @@ body { display: inline-block; margin: 0; }
   </tr>
   <tr>
     <td class='first-column' title='matter_wifi_917_ncp_window_app_freertos'>Matter WiFi - 917 NCP Window App FreeRTOS</td>
+    <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2035,6 +2097,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
+    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2066,6 +2129,7 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_closure_app_freertos'>Matter WiFi - SoC Closure FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2099,6 +2163,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
+    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2130,6 +2195,7 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_evse_app_freertos'>Matter WiFi - SoC EVSE FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2163,6 +2229,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
+    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2194,6 +2261,7 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_light_switch_app_freertos'>Matter WiFi - SoC Light Switch FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2227,6 +2295,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
+    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2258,6 +2327,7 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_lock_app_freertos'>Matter WiFi - SoC Lock FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2291,6 +2361,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
+    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2322,6 +2393,7 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_onoff_plug_app_freertos'>Matter WiFi - SoC Onoff Plug FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2355,6 +2427,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
+    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2386,6 +2459,7 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_platform_template_freertos'>Matter WiFi - SoC Platform Template FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2419,6 +2493,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
+    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2450,6 +2525,7 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_refrigerator_app_freertos'>Matter WiFi - SoC Refrigerator FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2483,6 +2559,7 @@ body { display: inline-block; margin: 0; }
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='compatible'>1</td>
+    <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
@@ -2514,6 +2591,7 @@ body { display: inline-block; margin: 0; }
     <td class='first-column' title='matter_wifi_soc_window_app_freertos'>Matter WiFi - SoC Window App FreeRTOS</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>
+    <td class='compatible'>1</td>
     <td class='compatible'>1</td>
     <td class='incompatible'>0</td>
     <td class='incompatible'>0</td>

--- a/matter_demos.xml
+++ b/matter_demos.xml
@@ -290,6 +290,16 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_air_quality_sensor_app_freertos" label="Matter WiFi - SoC Air Quality Sensor FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi air quality sensor app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Air Quality Sensor FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_air_quality_sensor_app_freertos_solution/artifact/matter_wifi_soc_air_quality_sensor_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/air_quality_sensor_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_closure_app_series_2_freertos" label="Matter Thread - SoC Closure with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread closure app with external bootloader. This configuration will increase power usage in EM2.</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Closure with external Bootloader FreeRTOS app"/>
@@ -580,6 +590,16 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_closure_app_freertos" label="Matter WiFi - SoC Closure FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi closure app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Closure FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_closure_app_freertos_solution/artifact/matter_wifi_soc_closure_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/closure_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_evse_app_series_2_freertos" label="Matter Thread - SoC EVSE with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread EVSE app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC EVSE with external Bootloader FreeRTOS app"/>
@@ -866,6 +886,16 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343a/matter_wifi_soc_evse_app_freertos_solution/artifact/matter_wifi_soc_evse_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/evse_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_evse_app_freertos" label="Matter WiFi - SoC EVSE FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi EVSE app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC EVSE FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_evse_app_freertos_solution/artifact/matter_wifi_soc_evse_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/evse_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -1200,6 +1230,16 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_fan_control_app_freertos" label="Matter WiFi - SoC Fan Control FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi fan control app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Fan Control FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_fan_control_app_freertos_solution/artifact/matter_wifi_soc_fan_control_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/fan_control_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_light_switch_app_series_2_freertos" label="Matter Thread - SoC Light Switch with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread light switch app with external bootloader. This configuration will increase power usage in EM2.</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Light Switch with external Bootloader FreeRTOS app"/>
@@ -1486,6 +1526,16 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343a/matter_wifi_soc_light_switch_app_freertos_solution/artifact/matter_wifi_soc_light_switch_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/light_switch_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_light_switch_app_freertos" label="Matter WiFi - SoC Light Switch FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi light switch app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Light Switch FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_light_switch_app_freertos_solution/artifact/matter_wifi_soc_light_switch_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/light_switch_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -1796,6 +1846,16 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343a/matter_wifi_soc_lighting_app_freertos_solution/artifact/matter_wifi_soc_lighting_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/lighting_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_lighting_app_freertos" label="Matter WiFi - SoC Lighting FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi lighting app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Lighting FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_lighting_app_freertos_solution/artifact/matter_wifi_soc_lighting_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/lighting_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -2130,6 +2190,16 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_lock_app_freertos" label="Matter WiFi - SoC Lock FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi door lock app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Lock FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_lock_app_freertos_solution/artifact/matter_wifi_soc_lock_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/lock_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_multi_sensor_app_series_2_freertos" label="Matter Thread - SoC Multi Sensor with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread multi-sensor app with external bootloader. This configuration will increase power usage in EM2.</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Multi Sensor with external Bootloader FreeRTOS app"/>
@@ -2416,6 +2486,16 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343a/matter_wifi_soc_multi_sensor_app_freertos_solution/artifact/matter_wifi_soc_multi_sensor_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/multi_sensor_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_multi_sensor_app_freertos" label="Matter WiFi - SoC Multi Sensor FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi multi-sensor app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Multi Sensor FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_multi_sensor_app_freertos_solution/artifact/matter_wifi_soc_multi_sensor_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/multi_sensor_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -2710,6 +2790,16 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_onoff_plug_app_freertos" label="Matter WiFi - SoC Onoff Plug FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi on/off plug app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Onoff Plug FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_onoff_plug_app_freertos_solution/artifact/matter_wifi_soc_onoff_plug_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/onoff_plug_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
   <demo name="brd2605a.demo.matter_wifi_soc_oven_app_freertos" label="Matter WiFi - SoC Oven FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi oven app</model:description>
     <property key="demos.blurb" value="Matter WiFi - SoC Oven FreeRTOS app"/>
@@ -2766,6 +2856,16 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343a/matter_wifi_soc_oven_app_freertos_solution/artifact/matter_wifi_soc_oven_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/oven_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_oven_app_freertos" label="Matter WiFi - SoC Oven FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi oven app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Oven FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_oven_app_freertos_solution/artifact/matter_wifi_soc_oven_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/oven_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -3060,6 +3160,16 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_platform_template_freertos" label="Matter WiFi - SoC Platform Template FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi platform template app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Platform Template FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_platform_template_freertos_solution/artifact/matter_wifi_soc_platform_template_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/platform_template/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_rangehood_app_series_2_freertos" label="Matter Thread - SoC Rangehood with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread rangehood app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Rangehood with external Bootloader FreeRTOS app"/>
@@ -3350,6 +3460,16 @@
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
   </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_rangehood_app_freertos" label="Matter WiFi - SoC Rangehood FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi rangehood app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Rangehood FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_rangehood_app_freertos_solution/artifact/matter_wifi_soc_rangehood_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/rangehood_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
   <demo name="brd2601b.demo.matter_thread_soc_refrigerator_app_series_2_freertos" label="Matter Thread - SoC Refrigerator with external Bootloader FreeRTOS">
     <model:description>Demonstrates a sample implementation of a Matter over Thread refrigerator app with external bootloader</model:description>
     <property key="demos.blurb" value="Matter Thread - SoC Refrigerator with external Bootloader FreeRTOS app"/>
@@ -3636,6 +3756,16 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343a/matter_wifi_soc_refrigerator_app_freertos_solution/artifact/matter_wifi_soc_refrigerator_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/refrigerator_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_refrigerator_app_freertos" label="Matter WiFi - SoC Refrigerator FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi refrigerator app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Refrigerator FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_refrigerator_app_freertos_solution/artifact/matter_wifi_soc_refrigerator_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/refrigerator_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -4026,6 +4156,16 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343a/matter_wifi_soc_thermostat_freertos_solution/artifact/matter_wifi_soc_thermostat_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/thermostat/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_thermostat_freertos" label="Matter WiFi - SoC Thermostat FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi thermostat app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Thermostat FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_thermostat_freertos_solution/artifact/matter_wifi_soc_thermostat_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/thermostat/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>
@@ -4446,6 +4586,16 @@
     <property key="core.partCompatibility" value=".*"/>
     <property key="core.boardCompatibility" value="brd4343a"/>
     <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343a/matter_wifi_soc_window_app_freertos_solution/artifact/matter_wifi_soc_window_app_freertos.rps"/>
+    <property key="core.readmeFiles" value="slc/apps/window_app/wifi/README.md"/>
+    <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <property key="core.quality" value="PRODUCTION"/>
+  </demo>
+  <demo name="brd4343c.demo.matter_wifi_soc_window_app_freertos" label="Matter WiFi - SoC Window App FreeRTOS">
+    <model:description>Demonstrates a sample implementation of a Matter over Wi-Fi window covering app</model:description>
+    <property key="demos.blurb" value="Matter WiFi - SoC Window App FreeRTOS app"/>
+    <property key="core.partCompatibility" value=".*"/>
+    <property key="core.boardCompatibility" value="brd4343c"/>
+    <property key="demos.imageFile" value="asset://extension.matter_2.9.0/demos/brd4343c/matter_wifi_soc_window_app_freertos_solution/artifact/matter_wifi_soc_window_app_freertos.rps"/>
     <property key="core.readmeFiles" value="slc/apps/window_app/wifi/README.md"/>
     <property key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <property key="core.quality" value="PRODUCTION"/>

--- a/matter_docs.xml
+++ b/matter_docs.xml
@@ -4,7 +4,7 @@
     <property key="core.category" value="Release Notes"/>
     <property key="core.priority" value="40"/>
     <property key="core.boardCompatibility" value="brd4116a brd4117a brd4118a brd4120a brd4121a brd4186c brd4187c brd2703a brd2704a brd2601b
-                brd2608a brd4316a brd4317a brd4319a brd4337a brd4318a brd1019a brd4350a brd4351a brd2709a brd2719a brd4407a brd4408a brd4338a brd4342a brd4343a brd2605a brd2708a brd2911a"/>
+                brd2608a brd4316a brd4317a brd4319a brd4337a brd4318a brd1019a brd4350a brd4351a brd2709a brd2719a brd4407a brd4408a brd4338a brd4342a brd4343a brd4343c brd2605a brd2708a brd2911a"/>
     <property key="core.partCompatibility" value=".*efr32mg26.* .*efr32mg24.* .*mgm24.* .*mgm26.* .*simg301.* .*si917.* .*siwg917.* "/>
     <property key="core.sdkAndProtocolTags" value="Matter"/>
     <description>Release Notes for the Silicon Labs Matter v2.9.0-1.6. These release notes provide information on the release including part compatibility, changes and added/deleted/deprecated features/API.</description>

--- a/matter_templates.xml
+++ b/matter_templates.xml
@@ -70,7 +70,7 @@
     <properties key="solutionReferenceId" value="slc.apps.air_quality_sensor_app.wifi.matter_wifi_soc_air_quality_sensor_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/air_quality_sensor_app/wifi/matter_wifi_soc_air_quality_sensor_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/air_quality_sensor_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -86,7 +86,7 @@
     <properties key="solutionReferenceId" value="slc.apps.air_quality_sensor_app.wifi.matter_wifi_soc_air_quality_sensor_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/air_quality_sensor_app/wifi/matter_wifi_soc_air_quality_sensor_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/air_quality_sensor_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -214,7 +214,7 @@
     <properties key="solutionReferenceId" value="slc.apps.closure_app.wifi.matter_wifi_soc_closure_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/closure_app/wifi/matter_wifi_soc_closure_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/closure_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -230,7 +230,7 @@
     <properties key="solutionReferenceId" value="slc.apps.closure_app.wifi.matter_wifi_soc_closure_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/closure_app/wifi/matter_wifi_soc_closure_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/closure_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -310,7 +310,7 @@
     <properties key="solutionReferenceId" value="slc.apps.evse_app.wifi.matter_wifi_soc_evse_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/evse_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -326,7 +326,7 @@
     <properties key="solutionReferenceId" value="slc.apps.evse_app.wifi.matter_wifi_soc_evse_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/evse_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -438,7 +438,7 @@
     <properties key="solutionReferenceId" value="slc.apps.fan_control_app.wifi.matter_wifi_soc_fan_control_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/fan_control_app/wifi/matter_wifi_soc_fan_control_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/fan_control_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -454,7 +454,7 @@
     <properties key="solutionReferenceId" value="slc.apps.fan_control_app.wifi.matter_wifi_soc_fan_control_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/fan_control_app/wifi/matter_wifi_soc_fan_control_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/fan_control_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -534,7 +534,7 @@
     <properties key="solutionReferenceId" value="slc.apps.light_switch_app.wifi.matter_wifi_soc_light_switch_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/light_switch_app/wifi/matter_wifi_soc_light_switch_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/light_switch_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -550,7 +550,7 @@
     <properties key="solutionReferenceId" value="slc.apps.light_switch_app.wifi.matter_wifi_soc_light_switch_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/light_switch_app/wifi/matter_wifi_soc_light_switch_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/light_switch_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -662,7 +662,7 @@
     <properties key="solutionReferenceId" value="slc.apps.lighting_app.wifi.matter_wifi_soc_lighting_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/lighting_app/wifi/matter_wifi_soc_lighting_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/lighting_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -678,7 +678,7 @@
     <properties key="solutionReferenceId" value="slc.apps.lighting_app.wifi.matter_wifi_soc_lighting_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/lighting_app/wifi/matter_wifi_soc_lighting_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/lighting_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -822,7 +822,7 @@
     <properties key="solutionReferenceId" value="slc.apps.lock_app.wifi.matter_wifi_soc_lock_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/lock_app/wifi/matter_wifi_soc_lock_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/lock_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -838,7 +838,7 @@
     <properties key="solutionReferenceId" value="slc.apps.lock_app.wifi.matter_wifi_soc_lock_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/lock_app/wifi/matter_wifi_soc_lock_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/lock_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -918,7 +918,7 @@
     <properties key="solutionReferenceId" value="slc.apps.multi_sensor_app.wifi.matter_wifi_soc_multi_sensor_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/multi_sensor_app/wifi/matter_wifi_soc_multi_sensor_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/multi_sensor_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -934,7 +934,7 @@
     <properties key="solutionReferenceId" value="slc.apps.multi_sensor_app.wifi.matter_wifi_soc_multi_sensor_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/multi_sensor_app/wifi/matter_wifi_soc_multi_sensor_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/multi_sensor_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1014,7 +1014,7 @@
     <properties key="solutionReferenceId" value="slc.apps.onoff_plug_app.wifi.matter_wifi_soc_onoff_plug_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/onoff_plug_app/wifi/matter_wifi_soc_onoff_plug_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/onoff_plug_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1030,7 +1030,7 @@
     <properties key="solutionReferenceId" value="slc.apps.onoff_plug_app.wifi.matter_wifi_soc_onoff_plug_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/onoff_plug_app/wifi/matter_wifi_soc_onoff_plug_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/onoff_plug_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1061,7 +1061,7 @@
     <properties key="solutionReferenceId" value="slc.apps.oven_app.wifi.matter_wifi_soc_oven_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/oven_app/wifi/matter_wifi_soc_oven_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/oven_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1077,7 +1077,7 @@
     <properties key="solutionReferenceId" value="slc.apps.oven_app.wifi.matter_wifi_soc_oven_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/oven_app/wifi/matter_wifi_soc_oven_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/oven_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1157,7 +1157,7 @@
     <properties key="solutionReferenceId" value="slc.apps.platform_template.wifi.matter_wifi_soc_platform_template_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/platform_template/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1173,7 +1173,7 @@
     <properties key="solutionReferenceId" value="slc.apps.platform_template.wifi.matter_wifi_soc_platform_template_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/platform_template/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1253,7 +1253,7 @@
     <properties key="solutionReferenceId" value="slc.apps.rangehood_app.wifi.matter_wifi_soc_rangehood_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/rangehood_app/wifi/matter_wifi_soc_rangehood_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/rangehood_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1269,7 +1269,7 @@
     <properties key="solutionReferenceId" value="slc.apps.rangehood_app.wifi.matter_wifi_soc_rangehood_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/rangehood_app/wifi/matter_wifi_soc_rangehood_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/rangehood_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1349,7 +1349,7 @@
     <properties key="solutionReferenceId" value="slc.apps.refrigerator_app.wifi.matter_wifi_soc_refrigerator_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/refrigerator_app/wifi/matter_wifi_soc_refrigerator_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/refrigerator_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1365,7 +1365,7 @@
     <properties key="solutionReferenceId" value="slc.apps.refrigerator_app.wifi.matter_wifi_soc_refrigerator_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/refrigerator_app/wifi/matter_wifi_soc_refrigerator_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/refrigerator_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1477,7 +1477,7 @@
     <properties key="solutionReferenceId" value="slc.apps.thermostat.wifi.matter_wifi_soc_thermostat_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/thermostat/wifi/matter_wifi_soc_thermostat_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/thermostat/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1493,7 +1493,7 @@
     <properties key="solutionReferenceId" value="slc.apps.thermostat.wifi.matter_wifi_soc_thermostat_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/thermostat/wifi/matter_wifi_soc_thermostat_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/thermostat/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1637,7 +1637,7 @@
     <properties key="solutionReferenceId" value="slc.apps.window_app.wifi.matter_wifi_soc_window_app_freertos.slcp"/>
     <properties key="projectFilePaths" value="slc/apps/window_app/wifi/matter_wifi_soc_window_app_freertos.slcp"/>
     <properties key="readmeFiles" value="slc/apps/window_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>
@@ -1653,7 +1653,7 @@
     <properties key="solutionReferenceId" value="slc.apps.window_app.wifi.matter_wifi_soc_window_app_freertos.slcw"/>
     <properties key="projectFilePaths" value="slc/apps/window_app/wifi/matter_wifi_soc_window_app_freertos.slcw"/>
     <properties key="readmeFiles" value="slc/apps/window_app/wifi/README.md"/>
-    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a com.silabs.board.none"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
     <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
     <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
     <properties key="toolchainCompatibility" value="gcc"/>

--- a/slc/component/matter-platform/display/matter_default_lcd_config.slcc
+++ b/slc/component/matter-platform/display/matter_default_lcd_config.slcc
@@ -26,6 +26,9 @@ requires:
   - name: matter_lcd_917SOC
     condition:
       - brd4343a
+  - name: matter_lcd_917SOC
+    condition:
+      - brd4343c
 
 # Keep this requirement under matter_lcd_917SOC's
   - name: matter_qr_code

--- a/slc/component/matter-platform/wstk-leds/matter_leds.slcc
+++ b/slc/component/matter-platform/wstk-leds/matter_leds.slcc
@@ -70,6 +70,10 @@ define:
   - name: ENABLE_WSTK_LEDS
     value: "1"
     condition:
+      - brd4343c
+  - name: ENABLE_WSTK_LEDS
+    value: "1"
+    condition:
       - brd4350a
   - name: ENABLE_WSTK_LEDS
     value: "1"

--- a/slc/script/hwfilter-config.yml
+++ b/slc/script/hwfilter-config.yml
@@ -47,6 +47,7 @@ board_allowlist:
     - brd4338a
     - brd4342a
     - brd4343a
+    - brd4343c
     - brd4350a
     - brd4351a
     - brd4407a


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** MATTER-6593

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** 
Added support for BRD4343C in matter_extension. Used BRD4343A as reference.
_Note: This is a copy of PR #788, as that is supposed to go to the relase branch because the WC 4.0.1 doesn't have the component brd4343c_

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
- Added brd4343c to full Wi‑Fi SoC builds in .github/silabs-builds-siwx.json (used by Dev Apps CI via platform-builder.yaml)
- Added brd4343c to boardCompatibility for all Matter Wi‑Fi SoC templates in matter_templates.xml
- Added 15 brd4343c demo entries in matter_demos.xml (mirroring brd4343a Wi‑Fi SoC demos)
- Added brd4343c to release notes board list in matter_docs.xml
- Added brd4343c to board_compatibility_matrix.html
- Added brd4343c to board allowlist in slc/script/hwfilter-config.yml
- Enabled WSTK LEDs and 917 SoC LCD for brd4343c in matter_leds.slcc and matter_default_lcd_config.slcc


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
- Tested local builds and basic sanity for both sleepy and non sleepy apps.
- Tested full build on CI - [Build Dev apps](https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/26815148567)
- Was not able to test it on studio as the board is not supported yet. Started a thread on slack channel - [#studio-matter-integration](https://silabsiot.slack.com/archives/C03THRXCQAU/p1780471342284989)