### PR TITLE
Remove stale include paths in component generation script

### DIFF
--- a/slc/script/gen_cluster_components.py
+++ b/slc/script/gen_cluster_components.py
@@ -216,11 +216,16 @@ for clustercomponentname in sorted(cluster_data.keys()):
         if len(current_include_data)>1:
             include = {}
             for i in range(len(current_include_data)):
-                if current_include_data[i]["path"] != cluster_data[clustercomponentname]["include"]:
-                    headers = []
-                    for header in current_include_data[i]["file_list"]:
-                        headers.append(header["path"])
-                    include = {"path": current_include_data[i]["path"], "file_list": headers}
+                inc_path = current_include_data[i]["path"]
+                if not os.path.isdir(inc_path) or inc_path == cluster_data[clustercomponentname]["include"]:
+                    continue
+                headers = []
+                for header in current_include_data[i]["file_list"]:
+                    if not os.path.isfile(os.path.join(inc_path, header["path"])):
+                        continue
+                    headers.append(header["path"])
+                if headers:
+                    include = {"path": inc_path, "file_list": headers}
                     includes.append(include)
         
         #merge with extracted define data and remove duplicates


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
`gen_cluster_components.py` currently preserves manually added include paths regardless of if they were deleted or not

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Update script to remove stale include paths

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Manual test locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-metadata generation only; no runtime auth, security, or product logic changes.
> 
> **Overview**
> When regenerating Matter cluster `.slcc` files, **manually added `include` blocks** from the previous file are now **validated against the filesystem** instead of being copied blindly.
> 
> Extra include directories are **dropped** if the path is missing or not a directory, or if it matches the cluster’s primary include. Listed headers are **kept only when the file exists** under that directory. An include entry is written **only if at least one header remains** after filtering.
> 
> This prevents deleted or moved include paths from lingering in generated components.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59880f196d5b5d4355abc930f173cd70e2d4b23a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->