### PR TITLE
Add test-event-trigger to wifi evse app

### DIFF
--- a/slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcp
+++ b/slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcp
@@ -15,107 +15,63 @@ sdk_extension:
 
 component:
   - id: matter_leds
-    from: matter
   - id: matter
-    from: matter
   - id: matter_wifi_ble
-    from: matter
   - id: matter_crypto_tinycrypt_siwx917
-    from: matter
 
   - id: mbedtls_pki_aws
     condition: [matter_aws]
-    from: matter
   - id: mbedtls_entropy_default_aws
     condition: [matter_aws]
-    from: matter
   - id: matter_wifi
-    from: matter
   - id: app_common
-    from: matter
   - id: matter_provision_flash
-    from: matter
 
   - id: matter_codegen_dm
   - id: matter_access_control
-    from: matter
   - id: matter_administrator_commissioning
-    from: matter
   - id: matter_basic_information
-    from: matter
   - id: matter_descriptor
-    from: matter
   - id: matter_diagnostic_logs
-    from: matter
   - id: matter_fixed_label
-    from: matter
   - id: matter_general_commissioning
-    from: matter
   - id: matter_general_diagnostics
-    from: matter
   - id: matter_group_key_mgmt
-    from: matter
   - id: matter_identify
-    from: matter
   - id: matter_localization_configuration
-    from: matter
   - id: matter_network_commissioning
-    from: matter
   - id: matter_operational_credentials
-    from: matter
   - id: matter_software_diagnostics
-    from: matter
   - id: matter_time_format_localization
-    from: matter
   - id: matter_user_label
-    from: matter
   - id: matter_wifi_network_diagnostics
-    from: matter
+  - id: matter_test_event_trigger
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    from: matter
   - id: segger_rtt
 
   - id: matter_ota_requestor
-    from: matter
   - id: matter_ota_support
-    from: matter
   - id: matter_power_source
-    from: matter
   - id: matter_shell
-    from: matter
   - id: matter_default_lcd_config
-    from: matter
   - id: matter_log_uart
-    from: matter
   - id: matter_lwip
-    from: matter
   # TODO: Remove this in the SiSDK 25Q4 release, where the LwIP fix will be included in the SiSDK.
   - id: sl_si91x_lwip_stack
     from: wiseconnect3_sdk
 
   - id: matter_evse
-    from: matter
   - id: matter_energy_evse
-    from: matter
   - id: matter_unit_localization
-    from: matter
   - id: matter_em_utils
-    from: matter
   - id: matter_em_triggers
-    from: matter
   - id: matter_dem
-    from: matter
   - id: matter_electrical_sensor
-    from: matter
   - id: matter_device_energy_management
-    from: matter
   - id: matter_electrical_energy_measurement
-    from: matter
   - id: matter_electrical_power_measurement
-    from: matter
   - id: matter_mode_base
-    from: matter
 
   - id: wifi_resources
     from: wiseconnect3_sdk


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

This is a followup to the comment on: https://github.com/SiliconLabsSoftware/matter_extension/pull/803.

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
https://jira.silabs.com/browse/MATTER-6483

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Test event triggers were not enabled on the EVSE app on matter extension.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Added the test event trigger component to the .slcp file.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Build -> Flash -> Commission +
mattertool generaldiagnostics read test-event-triggers-enabled 1 0
On brd4187c evse app.