### PR TITLE
MATTER-6587: Add dual stack lock app to CI

### DIFF
--- a/.github/silabs-builds-917-ncp-dual-stack.json
+++ b/.github/silabs-builds-917-ncp-dual-stack.json
@@ -1,0 +1,10 @@
+{
+    "custom-sqa": {
+        "lock_app": [
+            {
+                "boards": ["brd4120a", "brd4187c"],
+                "arguments": ["--with_app matter_aws,matter_aws_transport_nwp"]
+            }
+        ]
+    }
+}

--- a/.github/silabs-builds-917-ncp.json
+++ b/.github/silabs-builds-917-ncp.json
@@ -33,6 +33,12 @@
                 "boards": ["brd4187c"],
                 "arguments": ["--output_suffix brd4357a-copy-sources", "--with_app siwx917_ncp_brd4357a", "--copy-sources"]
             }
+        ],
+        "lock_app_dual_stack": [
+            {
+                "boards": ["brd4120a", "brd4187c"],
+                "arguments": [""]
+            }
         ]
     },
     "custom-sqa": {

--- a/.github/silabs-builds-917-ncp.json
+++ b/.github/silabs-builds-917-ncp.json
@@ -75,12 +75,6 @@
                 "arguments": ["--output_suffix brd4357a-m-ota-enc", "--without_app matter_ota_support",
                               "--with_app siwx917_ncp_brd4357a,matter_multi_image_ota,matter_multi_image_ota_encryption,matter_multi_image_custom_processor"]
             }
-        ],
-        "lock_app_dual_stack": [
-            {
-                "boards": ["brd4120a", "brd4187c"],
-                "arguments": ["--with_app matter_aws,matter_aws_transport_nwp"]
-            }
         ]
     }
 }

--- a/.github/silabs-builds-917-ncp.json
+++ b/.github/silabs-builds-917-ncp.json
@@ -33,6 +33,12 @@
                 "boards": ["brd4187c"],
                 "arguments": ["--output_suffix brd4357a-copy-sources", "--with_app siwx917_ncp_brd4357a", "--copy-sources"]
             }
+        ],
+        "lock_app": [
+            {
+                "boards": ["brd4187c"],
+                "arguments": ["--output_suffix matter_aws_transport_lwip", "--with_app matter_aws,matter_aws_transport_lwip"]
+            }
         ]
     },
     "custom-sqa": {

--- a/.github/silabs-builds-917-ncp.json
+++ b/.github/silabs-builds-917-ncp.json
@@ -33,12 +33,6 @@
                 "boards": ["brd4187c"],
                 "arguments": ["--output_suffix brd4357a-copy-sources", "--with_app siwx917_ncp_brd4357a", "--copy-sources"]
             }
-        ],
-        "lock_app_dual_stack": [
-            {
-                "boards": ["brd4120a", "brd4187c"],
-                "arguments": [""]
-            }
         ]
     },
     "custom-sqa": {
@@ -74,6 +68,12 @@
                 "boards": ["brd4187c"],
                 "arguments": ["--output_suffix brd4357a-m-ota-enc", "--without_app matter_ota_support",
                               "--with_app siwx917_ncp_brd4357a,matter_multi_image_ota,matter_multi_image_ota_encryption,matter_multi_image_custom_processor"]
+            }
+        ],
+        "lock_app_dual_stack": [
+            {
+                "boards": ["brd4120a", "brd4187c"],
+                "arguments": ["--with_app matter_aws,matter_aws_transport_nwp"]
             }
         ]
     }

--- a/.github/workflows/dev-apps-builder.yaml
+++ b/.github/workflows/dev-apps-builder.yaml
@@ -92,7 +92,6 @@ jobs:
             example-app: "lock_app"
             build-type: ${{ needs.set-build-type.outputs.build-type }}
             ncp-917-support: true
-            ncp-917-dual-stack-support: true
 
     build_thermostat_app:
         name: Build Thermostat App

--- a/.github/workflows/dev-apps-builder.yaml
+++ b/.github/workflows/dev-apps-builder.yaml
@@ -92,6 +92,7 @@ jobs:
             example-app: "lock_app"
             build-type: ${{ needs.set-build-type.outputs.build-type }}
             ncp-917-support: true
+            ncp-917-dual-stack-support: true
 
     build_thermostat_app:
         name: Build Thermostat App

--- a/.github/workflows/platform-builder.yaml
+++ b/.github/workflows/platform-builder.yaml
@@ -158,7 +158,7 @@ jobs:
             platform: ncp-917
 
     ncp-917-dual-stack-build-job:
-        if: ${{ inputs.ncp-917-dual-stack-support && inputs.build-type == 'full' }}
+        if: ${{ inputs.ncp-917-dual-stack-support && inputs.build-type == 'custom-sqa' }}
         uses: ./.github/workflows/builder.yaml
         with:
             json-file-path: './.github/silabs-builds-917-ncp.json'

--- a/.github/workflows/platform-builder.yaml
+++ b/.github/workflows/platform-builder.yaml
@@ -162,7 +162,7 @@ jobs:
         uses: ./.github/workflows/builder.yaml
         with:
             json-file-path: './.github/silabs-builds-917-ncp.json'
-            path-to-example-app: slc/apps/lock_app/wifi/matter_wifi_917_ncp_lock_app_dual_stack_freertos.slcw
+            path-to-example-app: slc/apps/${{ inputs.example-app }}/wifi/matter_wifi_917_ncp_${{ inputs.example-app }}_dual_stack_freertos.slcw
             example-app: lock_app_dual_stack
             build-type: ${{ inputs.build-type }}
             platform: ncp-917-dual-stack

--- a/.github/workflows/platform-builder.yaml
+++ b/.github/workflows/platform-builder.yaml
@@ -25,6 +25,10 @@ on:
                 required: false
                 type: boolean
                 default: false
+            ncp-917-dual-stack-support:
+                required: false
+                type: boolean
+                default: false
             mg24-support:
                 required: false
                 type: boolean
@@ -152,6 +156,16 @@ jobs:
             example-app: ${{ inputs.example-app }}
             build-type: ${{ inputs.build-type }}
             platform: ncp-917
+
+    ncp-917-dual-stack-build-job:
+        if: ${{ inputs.ncp-917-dual-stack-support && inputs.build-type == 'full' }}
+        uses: ./.github/workflows/builder.yaml
+        with:
+            json-file-path: './.github/silabs-builds-917-ncp.json'
+            path-to-example-app: slc/apps/lock_app/wifi/matter_wifi_917_ncp_lock_app_dual_stack_freertos.slcw
+            example-app: lock_app_dual_stack
+            build-type: ${{ inputs.build-type }}
+            platform: ncp-917-dual-stack
 
     siwx-soc-build-job:
         if: ${{ inputs.wifi-soc-support }}

--- a/.github/workflows/platform-builder.yaml
+++ b/.github/workflows/platform-builder.yaml
@@ -161,9 +161,9 @@ jobs:
         if: ${{ inputs.ncp-917-dual-stack-support && inputs.build-type == 'custom-sqa' }}
         uses: ./.github/workflows/builder.yaml
         with:
-            json-file-path: './.github/silabs-builds-917-ncp.json'
+            json-file-path: './.github/silabs-builds-917-ncp-dual-stack.json'
             path-to-example-app: slc/apps/${{ inputs.example-app }}/wifi/matter_wifi_917_ncp_${{ inputs.example-app }}_dual_stack_freertos.slcw
-            example-app: lock_app_dual_stack
+            example-app: ${{ inputs.example-app }}
             build-type: ${{ inputs.build-type }}
             platform: ncp-917-dual-stack
 

--- a/.github/workflows/sqa-apps-builder.yaml
+++ b/.github/workflows/sqa-apps-builder.yaml
@@ -11,6 +11,7 @@ jobs:
             example-app: "lock_app"
             build-type: "custom-sqa"
             ncp-917-support: true
+            ncp-917-dual-stack-support: true
             mgm24-internal-support: false
             mgm26-internal-support: false
 

--- a/slc/apps/lock_app/wifi/matter_wifi_917_ncp_lock_app_dual_stack_freertos.slcp
+++ b/slc/apps/lock_app/wifi/matter_wifi_917_ncp_lock_app_dual_stack_freertos.slcp
@@ -48,24 +48,18 @@ component:
   - id: matter_diagnostic_logs
   - id: matter_door_lock
   - id: matter_ethernet_network_diagnostics
-  - id: matter_fixed_label
   - id: matter_general_commissioning
   - id: matter_general_diagnostics
   - id: matter_group_key_mgmt
-  - id: matter_groups
   - id: matter_identify
-  - id: matter_localization_configuration
   - id: matter_network_commissioning
   - id: matter_operational_credentials
   - id: matter_ota_requestor
-  - id: matter_power_source_configuration
   - id: matter_power_source
   - id: matter_software_diagnostics
   - id: matter_thread_network_diagnostics
 
-  - id: matter_time_format_localization
   - id: matter_user_label
-  - id: matter_unit_localization
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** MATTER-6587

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** We are planning to execute the Split Stack test cases as part of the Feature Test Pipeline. To support this, we need the Split Stack application to be built for every release build.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
- Added dual stack lock app for 917 NCP to build-type custom-sqa. (Only triggered during full builds in main and release branches)
- Added one another example of matter_aws lock app for 917 NCP for full builds.
- Updated the dual stack lock app slcp file. Compared with the default ncp lock app slcp and removed the components which were not needed.
- Updated the matter_sdk pointer to pick up the fixes for build failure of dual stack lock app .


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
- Tested local build and basic functionality.
- Tested the Build SQA apps CI with the changes in a test branch - [CI Link](https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/27007808764/job/79703706133)
- Tested the Build Dev apps CI with full build - [CI Link](https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/27001894779/job/79684297796)