### PR TITLE
Provision library names updated

### DIFF
--- a/slc/component/matter-platform/device-attestation-credentials/matter_provision_default.slcc
+++ b/slc/component/matter-platform/device-attestation-credentials/matter_provision_default.slcc
@@ -45,7 +45,7 @@ source:
   - path: third_party/matter_sdk/examples/platform/silabs/provision/ProvisionStorageCustom.cpp
 
 library:
-  - path: third_party/matter_support/provision/libs/libProvision_efr32mg24.a
+  - path: third_party/matter_support/provision/libs/libProvision-efr32mg24.a
     condition:
       - device_family_efr32mg24
     unless: 
@@ -54,7 +54,7 @@ library:
     condition:
       - device_family_efr32mg24
       - toolchain_llvm
-  - path: third_party/matter_support/provision/libs/libProvision_efr32mg26.a
+  - path: third_party/matter_support/provision/libs/libProvision-efr32mg26.a
     condition:
       - device_family_efr32mg26
     unless:
@@ -63,7 +63,7 @@ library:
     condition:
       - device_family_efr32mg26
       - toolchain_llvm
-  - path: third_party/matter_support/provision/libs/libProvision_mgm24.a
+  - path: third_party/matter_support/provision/libs/libProvision-mgm24.a
     condition:
       - device_family_mgm24
     unless:
@@ -72,7 +72,7 @@ library:
     condition:
       - device_family_mgm24
       - toolchain_llvm
-  - path: third_party/matter_support/provision/libs/libProvision_efr32mg26.a
+  - path: third_party/matter_support/provision/libs/libProvision-efr32mg26.a
     condition:
       - device_family_mgm26
     unless:
@@ -81,10 +81,10 @@ library:
     condition:
       - device_family_mgm26
       - toolchain_llvm
-  - path: third_party/matter_support/provision/libs/libProvisionPSA_si917.a
+  - path: third_party/matter_support/provision/libs/libProvisionPSA-si917.a
     condition:
       - device_family_siwg917
-  - path: third_party/matter_support/provision/libs/libProvision_efr32mg24.a
+  - path: third_party/matter_support/provision/libs/libProvision-efr32mg24.a
     condition:
       - device_family_simg301
     unless:

--- a/slc/component/matter-platform/device-attestation-credentials/matter_provision_flash.slcc
+++ b/slc/component/matter-platform/device-attestation-credentials/matter_provision_flash.slcc
@@ -44,23 +44,23 @@ source:
   - path: third_party/matter_sdk/examples/platform/silabs/provision/ProvisionStorageCustom.cpp
 
 library:
-  - path: third_party/matter_support/provision/libs/libProvisionFlash_efr32mg24.a
+  - path: third_party/matter_support/provision/libs/libProvisionFlash-efr32mg24.a
     condition:
       - device_family_efr32mg24
-  - path: third_party/matter_support/provision/libs/libProvisionFlash_efr32mg26.a
+  - path: third_party/matter_support/provision/libs/libProvisionFlash-efr32mg26.a
     condition:
       - device_family_efr32mg26
-  - path: third_party/matter_support/provision/libs/libProvisionFlash_mgm24.a
+  - path: third_party/matter_support/provision/libs/libProvisionFlash-mgm24.a
     condition:
       - device_family_mgm24
-  - path: third_party/matter_support/provision/libs/libProvisionFlash_efr32mg26.a
+  - path: third_party/matter_support/provision/libs/libProvisionFlash-efr32mg26.a
     condition:
       - device_family_mgm26
-  - path: third_party/matter_support/provision/libs/libProvision_si917.a
+  - path: third_party/matter_support/provision/libs/libProvision-si917.a
     condition:
       - device_family_siwg917
       - matter_crypto_tinycrypt_siwx917
-  - path: third_party/matter_support/provision/libs/libProvisionPSA_si917.a
+  - path: third_party/matter_support/provision/libs/libProvisionPSA-si917.a
     condition:
       - device_family_siwg917
       - matter_crypto_psa_siwx917


### PR DESCRIPTION
Provision libraries have bee renamed.

**Issue Link:** 
N/A

**Description of Problem/Feature:**
Unless the components are updated, applications will use the outdated libraries with old names.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Names updated in the storage components.

**Testing Done:**
Lighting-app built after removing the old libraries (with outdated names).
Boards: BRD4187C (MG24), BRD4116A (MG26), BRD4338A (Si917).
