### PR TITLE
Fix output suffix for brd4187c lock app LTO custom-sqa

### DIFF
--- a/.github/silabs-builds-mg24.json
+++ b/.github/silabs-builds-mg24.json
@@ -125,7 +125,7 @@
             },
             {
                 "boards": ["brd4187c"],
-                "arguments": ["--output_suffix lto",
+                "arguments": ["--output_suffix sqa-lto",
                               "--with_app toolchain_gcc_lto"]
             },
             {


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Wrong output suffix for custom-sqa LTO binary.
<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Update output suffix.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI