### PR TITLE
NOJIRA: Temporary Fix for SQA Apps Builder

### DIFF
--- a/.github/workflows/dev-apps-builder.yaml
+++ b/.github/workflows/dev-apps-builder.yaml
@@ -280,7 +280,7 @@ jobs:
         name: Build Coverage
         needs:
             - set-build-type
-        if: ${{ github.ref_name == 'main' }}
+        if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'release_') || startsWith(github.ref_name, 'SL_compatibility') }}
         uses: ./.github/workflows/coverage-builder.yaml
         with:
             build-type: ${{ needs.set-build-type.outputs.build-type }}


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** N/A

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** 
the Build Dev Apps workflow skipped `build-sqa-apps` because -
- `build_coverage` was skipped (as it only runs for the main branch)
- Dependency - `build_coverage` <- `wait-for-test-results` <- `build-sqa-apps`
- GitHub Doc Reference - [Link](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-jobs#defining-prerequisite-jobs:~:text=If%20a%20run%20contains%20a%20series%20of%20jobs%20that%20need%20each%20other%2C%20a%20failure%20or%20skip%20applies%20to%20all%20jobs%20in%20the%20dependency%20chain%20from%20the%20point%20of%20failure%20or%20skip%20onwards.) 
- Slack thread for reference - [Link](https://silabsiot.slack.com/archives/C08KPSW43M1/p1781173351051299)

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Unblocking the SQA by temporarily adding release branch trigger. 


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Will be tested in the nightly build.