### PR TITLE
MATTER-6689: Add logging and error handling to hwfilter metadata generation script

### DIFF
--- a/slc/script/generate_metadata_hwfilter.py
+++ b/slc/script/generate_metadata_hwfilter.py
@@ -39,13 +39,19 @@ class Colors:
     YELLOW = '\033[1;33m'
     NC = '\033[0m'
 
-def log_info(message: str):
+def log_info(message: str, *args):
+    if args:
+        message = message % args
     print(f"{Colors.GREEN}[INFO]{Colors.NC} {message}")
 
-def log_warn(message: str):
+def log_warn(message: str, *args):
+    if args:
+        message = message % args
     print(f"{Colors.YELLOW}[WARN]{Colors.NC} {message}")
 
-def log_error(message: str):
+def log_error(message: str, *args):
+    if args:
+        message = message % args
     print(f"{Colors.RED}[ERROR]{Colors.NC} {message}")
 @dataclass(frozen=True)
 class CiJsonRecord:
@@ -516,19 +522,19 @@ def _run_hwstudio(
     returncode, stdout, stderr = run_command(cmd, check=False, capture=True)
 
     if returncode != 0:
-        log_error(f"hwstudio failed for {output_file} (exit code {returncode})")
+        log_error("hwstudio failed for %s (exit code %s)", output_file, returncode)
         if stderr.strip():
-            log_error(f"hwstudio stderr:\n{stderr.strip()}")
+            log_error("hwstudio stderr:\n%s", stderr.strip())
         if stdout.strip():
-            log_error(f"hwstudio stdout:\n{stdout.strip()}")
+            log_error("hwstudio stdout:\n%s", stdout.strip())
         return False
 
     if not out_path.exists():
-        log_error(f"hwstudio exited 0 but {output_file} was not created")
+        log_error("hwstudio exited 0 but %s was not created", output_file)
         return False
 
     if mtime_before is not None and out_path.stat().st_mtime == mtime_before:
-        log_error(f"hwstudio exited 0 but {output_file} was not updated (stale output)")
+        log_error("hwstudio exited 0 but %s was not updated (stale output)", output_file)
         return False
 
     return True
@@ -578,18 +584,18 @@ def generate_metadata(
             check=False, capture=True,
         )
         if rc != 0:
-            log_error(f"hwmatrix failed (exit code {rc})")
+            log_error("hwmatrix failed (exit code %s)", rc)
             if matrix_stderr.strip():
-                log_error(f"hwmatrix stderr:\n{matrix_stderr.strip()}")
+                log_error("hwmatrix stderr:\n%s", matrix_stderr.strip())
             failures.append(matrix)
         elif not matrix_path.exists() or (
             matrix_mtime_before is not None
             and matrix_path.stat().st_mtime == matrix_mtime_before
         ):
-            log_error(f"hwmatrix exited 0 but {matrix} was not updated")
+            log_error("hwmatrix exited 0 but %s was not updated", matrix)
             failures.append(matrix)
         else:
-            log_info(f"Generated {matrix}")
+            log_info("Generated %s", matrix)
 
     finally:
         for f in temp_files:
@@ -597,7 +603,7 @@ def generate_metadata(
                 f.unlink()
 
     if failures:
-        log_error(f"Metadata generation failed for: {', '.join(failures)}")
+        log_error("Metadata generation failed for: %s", ", ".join(failures))
         sys.exit(1)
 
 def main():

--- a/slc/script/generate_metadata_hwfilter.py
+++ b/slc/script/generate_metadata_hwfilter.py
@@ -509,8 +509,29 @@ def _run_hwstudio(
         "-t", str(template_path),
         "-q", "internal",
     ])
-    run_command(cmd, check=False, capture=True)
-    return Path(output_file).exists()
+
+    out_path = Path(output_file)
+    mtime_before = out_path.stat().st_mtime if out_path.exists() else None
+
+    returncode, stdout, stderr = run_command(cmd, check=False, capture=True)
+
+    if returncode != 0:
+        log_error(f"hwstudio failed for {output_file} (exit code {returncode})")
+        if stderr.strip():
+            log_error(f"hwstudio stderr:\n{stderr.strip()}")
+        if stdout.strip():
+            log_error(f"hwstudio stdout:\n{stdout.strip()}")
+        return False
+
+    if not out_path.exists():
+        log_error(f"hwstudio exited 0 but {output_file} was not created")
+        return False
+
+    if mtime_before is not None and out_path.stat().st_mtime == mtime_before:
+        log_error(f"hwstudio exited 0 but {output_file} was not updated (stale output)")
+        return False
+
+    return True
 
 def generate_metadata(
     repo_root: Path,
@@ -522,6 +543,7 @@ def generate_metadata(
     os.chdir(repo_root)
 
     temp_files = []
+    failures: List[str] = []
 
     try:
         temp_templates = prepare_template_with_version(
@@ -532,6 +554,8 @@ def generate_metadata(
         log_info("Generating templates XML...")
         if _run_hwstudio("matter_templates.xml", config_path, temp_templates):
             log_info("Generated matter_templates.xml")
+        else:
+            failures.append("matter_templates.xml")
 
         temp_demos = prepare_template_with_version(
             repo_root, "demos.xml.j2", slt_paths, ci_records, variants_config
@@ -541,20 +565,40 @@ def generate_metadata(
         log_info("Generating demos XML...")
         if _run_hwstudio("matter_demos.xml", config_path, temp_demos, demo=True):
             log_info("Generated matter_demos.xml")
+        else:
+            failures.append("matter_demos.xml")
 
         log_info("Generating board compatibility matrix...")
-        run_command(
-            ["hwmatrix", "-o", "board_compatibility_matrix.html",
+        matrix = "board_compatibility_matrix.html"
+        matrix_path = repo_root / matrix
+        matrix_mtime_before = matrix_path.stat().st_mtime if matrix_path.exists() else None
+        rc, _, matrix_stderr = run_command(
+            ["hwmatrix", "-o", matrix,
              "slc/apps/**/*.slc[pw]", "-c", str(config_path)],
             check=False, capture=True,
         )
-        if (repo_root / "board_compatibility_matrix.html").exists():
-            log_info("Generated board_compatibility_matrix.html")
+        if rc != 0:
+            log_error(f"hwmatrix failed (exit code {rc})")
+            if matrix_stderr.strip():
+                log_error(f"hwmatrix stderr:\n{matrix_stderr.strip()}")
+            failures.append(matrix)
+        elif not matrix_path.exists() or (
+            matrix_mtime_before is not None
+            and matrix_path.stat().st_mtime == matrix_mtime_before
+        ):
+            log_error(f"hwmatrix exited 0 but {matrix} was not updated")
+            failures.append(matrix)
+        else:
+            log_info(f"Generated {matrix}")
 
     finally:
         for f in temp_files:
             if f and f.exists():
                 f.unlink()
+
+    if failures:
+        log_error(f"Metadata generation failed for: {', '.join(failures)}")
+        sys.exit(1)
 
 def main():
     repo_root = _SCRIPT_DIR.parent.parent


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
MATTER-6689

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
hwfilter metadata generation script fails silently when it cannot detect packages
Currently script will fail due to hwfilter bug, this will be fixed on their side. Script will automatically pick this up since it clones latest main on each run. 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Add more logging and proper error handling to script to handle these failures 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Local testing 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only the metadata generation script’s error handling and exit behavior; no runtime product or security paths are affected.
> 
> **Overview**
> **Stops silent failures** when `hwstudio` / `hwmatrix` misbehave during Matter studio metadata generation in `generate_metadata_hwfilter.py`.
> 
> `log_info`, `log_warn`, and `log_error` now accept optional `%`-style format args. **`_run_hwstudio`** inspects exit code, logs captured stdout/stderr on failure, and treats success as invalid if the output file is missing or its mtime did not change (stale output). **`generate_metadata`** records failed artifacts (`matter_templates.xml`, `matter_demos.xml`, `board_compatibility_matrix.html`) and **`sys.exit(1)`** with a single error listing them. **`hwmatrix`** gets the same exit-code, stderr, and output-update checks.
> 
> CI and local runs will now fail explicitly when package detection or hwfilter tooling breaks, instead of printing success while leaving old or missing files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eef433e97a3c3511dea626e687dfa302fe1ba8be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->