### PR TITLE
BT stack increased for the Zigbee app in S3.

### DIFF
--- a/slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_freertos.slcp
+++ b/slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_freertos.slcp
@@ -169,7 +169,11 @@ configuration:
   - name: SL_LEGACY_HAL_DISABLE_WATCHDOG
     value: 1
   - name: SL_BT_RTOS_EVENT_HANDLER_STACK_SIZE
-    value: 1536
+    value: "1536"
+    unless: [device_series_3]
+  - name: SL_BT_RTOS_EVENT_HANDLER_STACK_SIZE
+    value: "2000"
+    condition: [device_series_3]
   - name: SL_BT_RTOS_LINK_LAYER_TASK_STACK_SIZE
     value: 1088
     condition:


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 

[MATTER-6136](https://jira.silabs.com/browse/MATTER-6136)

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
The application runs out of stack memory during BT provisioning in S3.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Increase the BT stack memory for S3. [Same fix done here](https://github.com/SiliconLabsSoftware/matter_extension/pull/527).

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Zigbee Lighting app provisioned with the BT channel with BRD4407A (Si301).