### PR TITLE
MATTER-6699: Remove USE_BYPASS_CLOCK for BRD4357C component

### DIFF
--- a/slc/component/matter-wifi/917-ncp/siwx917_ncp_brd4357c.slcc
+++ b/slc/component/matter-wifi/917-ncp/siwx917_ncp_brd4357c.slcc
@@ -16,7 +16,5 @@ requires:
   - name: siwx917_ncp
 
 define:
-  - name: USE_BYPASS_CLOCK
-    value: "1"
   - name: SL_SI91X_ACX_MODULE
     value: "1"


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** MATTER-6699

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:** 
The BRD4357C has support for 32KHz clock from external XTAL OSCILLATOR.

BRD4357C A03 Schematic -
<img width="399" height="286" alt="image" src="https://github.com/user-attachments/assets/5c0a37d0-ef6a-438b-abc2-ffa7391e79b7" />

So it doesn't need to use the BYPASS CLK like BRD4357A, in that case we need to remove the `USE_BYPASS_CLOCK` from the slcc file.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Removed  `USE_BYPASS_CLOCK` from `slc/component/matter-wifi/917-ncp/siwx917_ncp_brd4357c.slcc`



<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Tested commissioning, commands and powercycle for sleepy and non sleepy apps for 917NCP (BRD4187C + BRD4357C)