### PR TITLE
Adding the slcp and slcw files in the matter_templates.xml

### DIFF
--- a/matter_templates.xml
+++ b/matter_templates.xml
@@ -1728,4 +1728,237 @@
     <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
     <properties key="solutionProjects" value="slc.apps.bootloaders.bootloader_storage_single_4096k_series_3.matter_bootloader_internal_series_3.slcp slc.apps.zigbee_light.thread.matter_thread_soc_zigbee_light_freertos.slcp"/>
   </descriptors>
+  <descriptors name="matter-platform" label="matter-platform" description="This project contains the minimal requirements to generate the dependencies needed by all Matter examples">
+    <properties key="namespace" value="template.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="third_party.matter_sdk.examples.platform.silabs.matter-platform.slcp"/>
+    <properties key="projectFilePaths" value="third_party/matter_sdk/examples/platform/silabs/matter-platform.slcp"/>
+    <properties key="readmeFiles" value="slc/apps/platform_template/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd1019a brd2601b brd2608a brd2703a brd2704a brd2709a brd2719a brd4116a brd4117a brd4118a brd4120a brd4121a brd4186c brd4187c brd4316a brd4317a brd4318a brd4319a brd4337a brd4350a brd4351a brd4407a brd4408a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*efr32mg24a010f1536gm40.* .*efr32mg24a010f1536gm48.* .*efr32mg24a010f1536im40.* .*efr32mg24a010f1536im48.* .*efr32mg24a020f1536gm40.* .*efr32mg24a020f1536gm48.* .*efr32mg24a020f1536im40.* .*efr32mg24a020f1536im48.* .*efr32mg24a110f1536gm48.* .*efr32mg24a111f1536gm48.* .*efr32mg24a120f1536gm48.* .*efr32mg24a121f1536gm48.* .*efr32mg24a410f1536im40.* .*efr32mg24a410f1536im48.* .*efr32mg24a420f1536im40.* .*efr32mg24a420f1536im48.* .*efr32mg24a610f1536im40.* .*efr32mg24a620f1536im40.* .*efr32mg24b010f1536im40.* .*efr32mg24b010f1536im48.* .*efr32mg24b020f1536im40.* .*efr32mg24b020f1536im48.* .*efr32mg24b110f1536gm48.* .*efr32mg24b110f1536im48.* .*efr32mg24b120f1536im48.* .*efr32mg24b210f1536im40.* .*efr32mg24b210f1536im48.* .*efr32mg24b220f1536im48.* .*efr32mg24b310f1536im48.* .*efr32mg24b610f1536im40.* .*efr32mg26b211f2048im68.* .*efr32mg26b211f3200im48.* .*efr32mg26b221f2048im68.* .*efr32mg26b221f3200im48.* .*efr32mg26b311f3200il136.* .*efr32mg26b410f3200im48.* .*efr32mg26b410f3200im68.* .*efr32mg26b411f3200im48.* .*efr32mg26b411f3200im68.* .*efr32mg26b420f3200im48.* .*efr32mg26b420f3200im68.* .*efr32mg26b421f3200im48.* .*efr32mg26b421f3200im68.* .*efr32mg26b510f3200il136.* .*efr32mg26b510f3200im48.* .*efr32mg26b510f3200im68.* .*efr32mg26b511f3200il136.* .*efr32mg26b511f3200im48.* .*efr32mg26b511f3200im68.* .*efr32mg26b520f3200im48.* .*efr32mg26b520f3200im68.* .*efr32mg26b521f3200im48.* .*efr32mg26b521f3200im68.* .*efr32mg26b610f3200im48.* .*efr32mg26b611f2048im48.* .*mgm240l022rnf.* .*mgm240l022vif.* .*mgm240l022vnf.* .*mgm240la22uif.* .*mgm240la22vif.* .*mgm240ld22vif.* .*mgm240pa22vna.* .*mgm240pa32vna.* .*mgm240pa32vnn.* .*mgm240pb22vna.* .*mgm240pb32vna.* .*mgm240pb32vnn.* .*mgm240sa22vna.* .*mgm240sb22vna.* .*mgm240sd22vna.* .*mgm260pb22vna.* .*mgm260pb32vna.* .*mgm260pb32vnn.* .*mgm260pd22vna.* .*mgm260pd32vna.* .*mgm260pd32vnn.* .*simg301m103lih.* .*simg301m103wih.* .*simg301m104lgh.* .*simg301m104lgl.* .*simg301m104lih.* .*simg301m104lil.* .*simg301m104xil.* .*simg301m113wih.* .*simg301m114kgh.* .*simg301m114kih.* .*simg301m114lgh.* .*simg301m114lih.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Examples"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_code_size_sensor_freertos" label="Matter Thread - SoC Code Size Sensor FreeRTOS" description="Demonstrates a sample implementation of a minimal sensor app used for code size analysis">
+    <properties key="namespace" value="template.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.code_size_sensor.thread.matter_thread_soc_code_size_sensor_freertos.slcp"/>
+    <properties key="projectFilePaths" value="slc/apps/code_size_sensor/thread/matter_thread_soc_code_size_sensor_freertos.slcp"/>
+    <properties key="readmeFiles" value="slc/apps/multi_sensor_app/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd1019a brd2601b brd2608a brd2703a brd2704a brd2709a brd2719a brd4116a brd4117a brd4118a brd4120a brd4121a brd4186c brd4187c brd4316a brd4317a brd4318a brd4319a brd4337a brd4350a brd4351a brd4407a brd4408a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*efr32mg24a010f1536gm40.* .*efr32mg24a010f1536gm48.* .*efr32mg24a010f1536im40.* .*efr32mg24a010f1536im48.* .*efr32mg24a020f1536gm40.* .*efr32mg24a020f1536gm48.* .*efr32mg24a020f1536im40.* .*efr32mg24a020f1536im48.* .*efr32mg24a110f1536gm48.* .*efr32mg24a111f1536gm48.* .*efr32mg24a120f1536gm48.* .*efr32mg24a121f1536gm48.* .*efr32mg24a410f1536im40.* .*efr32mg24a410f1536im48.* .*efr32mg24a420f1536im40.* .*efr32mg24a420f1536im48.* .*efr32mg24a610f1536im40.* .*efr32mg24a620f1536im40.* .*efr32mg24b010f1536im40.* .*efr32mg24b010f1536im48.* .*efr32mg24b020f1536im40.* .*efr32mg24b020f1536im48.* .*efr32mg24b110f1536gm48.* .*efr32mg24b110f1536im48.* .*efr32mg24b120f1536im48.* .*efr32mg24b210f1536im40.* .*efr32mg24b210f1536im48.* .*efr32mg24b220f1536im48.* .*efr32mg24b310f1536im48.* .*efr32mg24b610f1536im40.* .*efr32mg26b211f2048im68.* .*efr32mg26b211f3200im48.* .*efr32mg26b221f2048im68.* .*efr32mg26b221f3200im48.* .*efr32mg26b311f3200il136.* .*efr32mg26b410f3200im48.* .*efr32mg26b410f3200im68.* .*efr32mg26b411f3200im48.* .*efr32mg26b411f3200im68.* .*efr32mg26b420f3200im48.* .*efr32mg26b420f3200im68.* .*efr32mg26b421f3200im48.* .*efr32mg26b421f3200im68.* .*efr32mg26b510f3200il136.* .*efr32mg26b510f3200im48.* .*efr32mg26b510f3200im68.* .*efr32mg26b511f3200il136.* .*efr32mg26b511f3200im48.* .*efr32mg26b511f3200im68.* .*efr32mg26b520f3200im48.* .*efr32mg26b520f3200im68.* .*efr32mg26b521f3200im48.* .*efr32mg26b521f3200im68.* .*efr32mg26b610f3200im48.* .*efr32mg26b611f2048im48.* .*mgm240l022rnf.* .*mgm240l022vif.* .*mgm240l022vnf.* .*mgm240la22uif.* .*mgm240la22vif.* .*mgm240ld22vif.* .*mgm240pa22vna.* .*mgm240pa32vna.* .*mgm240pa32vnn.* .*mgm240pb22vna.* .*mgm240pb32vna.* .*mgm240pb32vnn.* .*mgm240sa22vna.* .*mgm240sb22vna.* .*mgm240sd22vna.* .*mgm260pb22vna.* .*mgm260pb32vna.* .*mgm260pb32vnn.* .*mgm260pd22vna.* .*mgm260pd32vna.* .*mgm260pd32vnn.* .*simg301m103lih.* .*simg301m103wih.* .*simg301m104lgh.* .*simg301m104lgl.* .*simg301m104lih.* .*simg301m104lil.* .*simg301m104xil.* .*simg301m113wih.* .*simg301m114kgh.* .*simg301m114kih.* .*simg301m114lgh.* .*simg301m114lih.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_performance_test_app_freertos" label="Matter Thread - SoC Performance Test FreeRTOS" description="Demonstrates a sample implementation of a Matter over Thread performance test app">
+    <properties key="namespace" value="template.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.performance_test_app.thread.matter_thread_soc_performance_test_app_freertos.slcp"/>
+    <properties key="projectFilePaths" value="slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_freertos.slcp"/>
+    <properties key="readmeFiles" value="slc/apps/performance_test_app/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd1019a brd2601b brd2608a brd2703a brd2704a brd2709a brd2719a brd4116a brd4117a brd4118a brd4120a brd4121a brd4186c brd4187c brd4316a brd4317a brd4318a brd4319a brd4337a brd4350a brd4351a brd4407a brd4408a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*efr32mg24a010f1536gm40.* .*efr32mg24a010f1536gm48.* .*efr32mg24a010f1536im40.* .*efr32mg24a010f1536im48.* .*efr32mg24a020f1536gm40.* .*efr32mg24a020f1536gm48.* .*efr32mg24a020f1536im40.* .*efr32mg24a020f1536im48.* .*efr32mg24a110f1536gm48.* .*efr32mg24a111f1536gm48.* .*efr32mg24a120f1536gm48.* .*efr32mg24a121f1536gm48.* .*efr32mg24a410f1536im40.* .*efr32mg24a410f1536im48.* .*efr32mg24a420f1536im40.* .*efr32mg24a420f1536im48.* .*efr32mg24a610f1536im40.* .*efr32mg24a620f1536im40.* .*efr32mg24b010f1536im40.* .*efr32mg24b010f1536im48.* .*efr32mg24b020f1536im40.* .*efr32mg24b020f1536im48.* .*efr32mg24b110f1536gm48.* .*efr32mg24b110f1536im48.* .*efr32mg24b120f1536im48.* .*efr32mg24b210f1536im40.* .*efr32mg24b210f1536im48.* .*efr32mg24b220f1536im48.* .*efr32mg24b310f1536im48.* .*efr32mg24b610f1536im40.* .*efr32mg26b211f2048im68.* .*efr32mg26b211f3200im48.* .*efr32mg26b221f2048im68.* .*efr32mg26b221f3200im48.* .*efr32mg26b311f3200il136.* .*efr32mg26b410f3200im48.* .*efr32mg26b410f3200im68.* .*efr32mg26b411f3200im48.* .*efr32mg26b411f3200im68.* .*efr32mg26b420f3200im48.* .*efr32mg26b420f3200im68.* .*efr32mg26b421f3200im48.* .*efr32mg26b421f3200im68.* .*efr32mg26b510f3200il136.* .*efr32mg26b510f3200im48.* .*efr32mg26b510f3200im68.* .*efr32mg26b511f3200il136.* .*efr32mg26b511f3200im48.* .*efr32mg26b511f3200im68.* .*efr32mg26b520f3200im48.* .*efr32mg26b520f3200im68.* .*efr32mg26b521f3200im48.* .*efr32mg26b521f3200im68.* .*efr32mg26b610f3200im48.* .*efr32mg26b611f2048im48.* .*mgm240l022rnf.* .*mgm240l022vif.* .*mgm240l022vnf.* .*mgm240la22uif.* .*mgm240la22vif.* .*mgm240ld22vif.* .*mgm240pa22vna.* .*mgm240pa32vna.* .*mgm240pa32vnn.* .*mgm240pb22vna.* .*mgm240pb32vna.* .*mgm240pb32vnn.* .*mgm240sa22vna.* .*mgm240sb22vna.* .*mgm240sd22vna.* .*mgm260pb22vna.* .*mgm260pb32vna.* .*mgm260pb32vnn.* .*mgm260pd22vna.* .*mgm260pd32vna.* .*mgm260pd32vnn.* .*simg301m103lih.* .*simg301m103wih.* .*simg301m104lgh.* .*simg301m104lgl.* .*simg301m104lih.* .*simg301m104lil.* .*simg301m104xil.* .*simg301m113wih.* .*simg301m114kgh.* .*simg301m114kih.* .*simg301m114lgh.* .*simg301m114lih.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_performance_test_app_series_2_freertos" label="Matter Thread - SoC Performance Test with external Bootloader FreeRTOS" description="Demonstrates a sample implementation of a Matter over Thread performance test app with external bootloader">
+    <properties key="namespace" value="template.solution.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.performance_test_app.thread.matter_thread_soc_performance_test_app_series_2_freertos.slcw"/>
+    <properties key="projectFilePaths" value="slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_series_2_freertos.slcw"/>
+    <properties key="readmeFiles" value="slc/apps/performance_test_app/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd2601b brd2608a brd4116a brd4117a brd4118a brd4120a brd4121a brd4186c brd4187c brd4316a brd4317a brd4318a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*efr32mg24a010f1536gm40.* .*efr32mg24a010f1536gm48.* .*efr32mg24a010f1536im40.* .*efr32mg24a010f1536im48.* .*efr32mg24a020f1536gm40.* .*efr32mg24a020f1536gm48.* .*efr32mg24a020f1536im40.* .*efr32mg24a020f1536im48.* .*efr32mg24a110f1536gm48.* .*efr32mg24a111f1536gm48.* .*efr32mg24a120f1536gm48.* .*efr32mg24a121f1536gm48.* .*efr32mg24a410f1536im40.* .*efr32mg24a410f1536im48.* .*efr32mg24a420f1536im40.* .*efr32mg24a420f1536im48.* .*efr32mg24a610f1536im40.* .*efr32mg24a620f1536im40.* .*efr32mg24b010f1536im40.* .*efr32mg24b010f1536im48.* .*efr32mg24b020f1536im40.* .*efr32mg24b020f1536im48.* .*efr32mg24b110f1536gm48.* .*efr32mg24b110f1536im48.* .*efr32mg24b120f1536im48.* .*efr32mg24b210f1536im40.* .*efr32mg24b210f1536im48.* .*efr32mg24b220f1536im48.* .*efr32mg24b310f1536im48.* .*efr32mg24b610f1536im40.* .*efr32mg26b211f2048im68.* .*efr32mg26b211f3200im48.* .*efr32mg26b221f2048im68.* .*efr32mg26b221f3200im48.* .*efr32mg26b311f3200il136.* .*efr32mg26b410f3200im48.* .*efr32mg26b410f3200im68.* .*efr32mg26b411f3200im48.* .*efr32mg26b411f3200im68.* .*efr32mg26b420f3200im48.* .*efr32mg26b420f3200im68.* .*efr32mg26b421f3200im48.* .*efr32mg26b421f3200im68.* .*efr32mg26b510f3200il136.* .*efr32mg26b510f3200im48.* .*efr32mg26b510f3200im68.* .*efr32mg26b511f3200il136.* .*efr32mg26b511f3200im48.* .*efr32mg26b511f3200im68.* .*efr32mg26b520f3200im48.* .*efr32mg26b520f3200im68.* .*efr32mg26b521f3200im48.* .*efr32mg26b521f3200im68.* .*efr32mg26b610f3200im48.* .*efr32mg26b611f2048im48.* .*mgm240l022rnf.* .*mgm240l022vif.* .*mgm240l022vnf.* .*mgm240la22uif.* .*mgm240la22vif.* .*mgm240ld22vif.* .*mgm240pa22vna.* .*mgm240pa32vna.* .*mgm240pa32vnn.* .*mgm240pb22vna.* .*mgm240pb32vna.* .*mgm240pb32vnn.* .*mgm240sa22vna.* .*mgm240sb22vna.* .*mgm240sd22vna.* .*mgm260pb22vna.* .*mgm260pb32vna.* .*mgm260pb32vnn.* .*mgm260pd22vna.* .*mgm260pd32vna.* .*mgm260pd32vnn.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="solutionProjects" value="slc.apps.bootloaders.bootloader_storage_external_single_series_2.matter_bootloader_external_series_2.slcp slc.apps.performance_test_app.thread.matter_thread_soc_performance_test_app_freertos.slcp"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_performance_test_app_series_2_internal_freertos" label="Matter Thread - SoC Performance Test with internal Bootloader FreeRTOS" description="Demonstrates a sample implementation of a Matter over Thread performance test app with internal bootloader">
+    <properties key="namespace" value="template.solution.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.performance_test_app.thread.matter_thread_soc_performance_test_app_series_2_internal_freertos.slcw"/>
+    <properties key="projectFilePaths" value="slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_series_2_internal_freertos.slcw"/>
+    <properties key="readmeFiles" value="slc/apps/performance_test_app/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd2703a brd2704a brd2709a brd4319a brd4337a brd4350a brd4351a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*efr32mg24a010f1536gm40.* .*efr32mg24a010f1536gm48.* .*efr32mg24a010f1536im40.* .*efr32mg24a010f1536im48.* .*efr32mg24a020f1536gm40.* .*efr32mg24a020f1536gm48.* .*efr32mg24a020f1536im40.* .*efr32mg24a020f1536im48.* .*efr32mg24a110f1536gm48.* .*efr32mg24a111f1536gm48.* .*efr32mg24a120f1536gm48.* .*efr32mg24a121f1536gm48.* .*efr32mg24a410f1536im40.* .*efr32mg24a410f1536im48.* .*efr32mg24a420f1536im40.* .*efr32mg24a420f1536im48.* .*efr32mg24a610f1536im40.* .*efr32mg24a620f1536im40.* .*efr32mg24b010f1536im40.* .*efr32mg24b010f1536im48.* .*efr32mg24b020f1536im40.* .*efr32mg24b020f1536im48.* .*efr32mg24b110f1536gm48.* .*efr32mg24b110f1536im48.* .*efr32mg24b120f1536im48.* .*efr32mg24b210f1536im40.* .*efr32mg24b210f1536im48.* .*efr32mg24b220f1536im48.* .*efr32mg24b310f1536im48.* .*efr32mg24b610f1536im40.* .*efr32mg26b211f2048im68.* .*efr32mg26b211f3200im48.* .*efr32mg26b221f2048im68.* .*efr32mg26b221f3200im48.* .*efr32mg26b311f3200il136.* .*efr32mg26b410f3200im48.* .*efr32mg26b410f3200im68.* .*efr32mg26b411f3200im48.* .*efr32mg26b411f3200im68.* .*efr32mg26b420f3200im48.* .*efr32mg26b420f3200im68.* .*efr32mg26b421f3200im48.* .*efr32mg26b421f3200im68.* .*efr32mg26b510f3200il136.* .*efr32mg26b510f3200im48.* .*efr32mg26b510f3200im68.* .*efr32mg26b511f3200il136.* .*efr32mg26b511f3200im48.* .*efr32mg26b511f3200im68.* .*efr32mg26b520f3200im48.* .*efr32mg26b520f3200im68.* .*efr32mg26b521f3200im48.* .*efr32mg26b521f3200im68.* .*efr32mg26b610f3200im48.* .*efr32mg26b611f2048im48.* .*mgm240l022rnf.* .*mgm240l022vif.* .*mgm240l022vnf.* .*mgm240la22uif.* .*mgm240la22vif.* .*mgm240ld22vif.* .*mgm240pa22vna.* .*mgm240pa32vna.* .*mgm240pa32vnn.* .*mgm240pb22vna.* .*mgm240pb32vna.* .*mgm240pb32vnn.* .*mgm240sa22vna.* .*mgm240sb22vna.* .*mgm240sd22vna.* .*mgm260pb22vna.* .*mgm260pb32vna.* .*mgm260pb32vnn.* .*mgm260pd22vna.* .*mgm260pd32vna.* .*mgm260pd32vnn.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="solutionProjects" value="slc.apps.bootloaders.bootloader_storage_internal_single_series_2.matter_bootloader_internal_series_2.slcp slc.apps.performance_test_app.thread.matter_thread_soc_performance_test_app_freertos.slcp"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_performance_test_app_series_3_freertos" label="Matter Thread - SoC Performance Test with internal Bootloader FreeRTOS" description="Demonstrates a sample implementation of a Matter over Thread performance test app with internal bootloader">
+    <properties key="namespace" value="template.solution.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.performance_test_app.thread.matter_thread_soc_performance_test_app_series_3_freertos.slcw"/>
+    <properties key="projectFilePaths" value="slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_series_3_freertos.slcw"/>
+    <properties key="readmeFiles" value="slc/apps/performance_test_app/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd1019a brd2719a brd4407a brd4408a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*simg301m103lih.* .*simg301m103wih.* .*simg301m104lgh.* .*simg301m104lgl.* .*simg301m104lih.* .*simg301m104lil.* .*simg301m104xil.* .*simg301m113wih.* .*simg301m114kgh.* .*simg301m114kih.* .*simg301m114lgh.* .*simg301m114lih.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="solutionProjects" value="slc.apps.bootloaders.bootloader_storage_single_4096k_series_3.matter_bootloader_internal_series_3.slcp slc.apps.performance_test_app.thread.matter_thread_soc_performance_test_app_freertos.slcp"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_bootloader_internal_series_3_solution" label="Matter - SoC Bootloader Internal Storage Series 3" description="Demonstrates a bootloader solution using internal storage for Matter firmware updates on Series 3 devices">
+    <properties key="namespace" value="template.solution.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.bootloaders.bootloader_storage_single_4096k_series_3.matter_bootloader_internal_series_3.slcw"/>
+    <properties key="projectFilePaths" value="slc/apps/bootloaders/bootloader_storage_single_4096k_series_3/matter_bootloader_internal_series_3.slcw"/>
+    <properties key="readmeFiles" value="slc/apps/bootloaders/bootloader_storage_single_4096k_series_3/readme.md"/>
+    <properties key="boardCompatibility" value="brd1019a brd2719a brd4407a brd4408a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*simg301m103lih.* .*simg301m103wih.* .*simg301m104lgh.* .*simg301m104lgl.* .*simg301m104lih.* .*simg301m104lil.* .*simg301m104xil.* .*simg301m113wih.* .*simg301m114kgh.* .*simg301m114kih.* .*simg301m114lgh.* .*simg301m114lih.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="solutionProjects" value="slc.apps.bootloaders.bootloader_storage_single_4096k_series_3.matter_bootloader_internal_series_3.slcp"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_zigbee_light_series_2_freertos" label="Matter Thread - SoC Zigbee Light with external Bootloader FreeRTOS" description="Demonstrates a sample implementation of a Matter and Zigbee multiprotocol lighting app over Thread with external bootloader">
+    <properties key="namespace" value="template.solution.uc"/>
+    <properties key="keywords" value="Matter Zigbee"/>
+    <properties key="solutionReferenceId" value="slc.apps.zigbee_light.thread.matter_thread_soc_zigbee_light_series_2_freertos.slcw"/>
+    <properties key="projectFilePaths" value="slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_series_2_freertos.slcw"/>
+    <properties key="readmeFiles" value="slc/apps/zigbee_light/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd2601b brd2608a brd4116a brd4117a brd4118a brd4120a brd4121a brd4186c brd4187c brd4316a brd4317a brd4318a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*efr32mg24a010f1536gm40.* .*efr32mg24a010f1536gm48.* .*efr32mg24a010f1536im40.* .*efr32mg24a010f1536im48.* .*efr32mg24a020f1536gm40.* .*efr32mg24a020f1536gm48.* .*efr32mg24a020f1536im40.* .*efr32mg24a020f1536im48.* .*efr32mg24a110f1536gm48.* .*efr32mg24a111f1536gm48.* .*efr32mg24a120f1536gm48.* .*efr32mg24a121f1536gm48.* .*efr32mg24a410f1536im40.* .*efr32mg24a410f1536im48.* .*efr32mg24a420f1536im40.* .*efr32mg24a420f1536im48.* .*efr32mg24a610f1536im40.* .*efr32mg24a620f1536im40.* .*efr32mg24b010f1536im40.* .*efr32mg24b010f1536im48.* .*efr32mg24b020f1536im40.* .*efr32mg24b020f1536im48.* .*efr32mg24b110f1536gm48.* .*efr32mg24b110f1536im48.* .*efr32mg24b120f1536im48.* .*efr32mg24b210f1536im40.* .*efr32mg24b210f1536im48.* .*efr32mg24b220f1536im48.* .*efr32mg24b310f1536im48.* .*efr32mg24b610f1536im40.* .*efr32mg26b211f2048im68.* .*efr32mg26b211f3200im48.* .*efr32mg26b221f2048im68.* .*efr32mg26b221f3200im48.* .*efr32mg26b311f3200il136.* .*efr32mg26b410f3200im48.* .*efr32mg26b410f3200im68.* .*efr32mg26b411f3200im48.* .*efr32mg26b411f3200im68.* .*efr32mg26b420f3200im48.* .*efr32mg26b420f3200im68.* .*efr32mg26b421f3200im48.* .*efr32mg26b421f3200im68.* .*efr32mg26b510f3200il136.* .*efr32mg26b510f3200im48.* .*efr32mg26b510f3200im68.* .*efr32mg26b511f3200il136.* .*efr32mg26b511f3200im48.* .*efr32mg26b511f3200im68.* .*efr32mg26b520f3200im48.* .*efr32mg26b520f3200im68.* .*efr32mg26b521f3200im48.* .*efr32mg26b521f3200im68.* .*efr32mg26b610f3200im48.* .*efr32mg26b611f2048im48.* .*mgm240l022rnf.* .*mgm240l022vif.* .*mgm240l022vnf.* .*mgm240la22uif.* .*mgm240la22vif.* .*mgm240ld22vif.* .*mgm240pa22vna.* .*mgm240pa32vna.* .*mgm240pa32vnn.* .*mgm240pb22vna.* .*mgm240pb32vna.* .*mgm240pb32vnn.* .*mgm240sa22vna.* .*mgm240sb22vna.* .*mgm240sd22vna.* .*mgm260pb22vna.* .*mgm260pb32vna.* .*mgm260pb32vnn.* .*mgm260pd22vna.* .*mgm260pd32vna.* .*mgm260pd32vnn.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="solutionProjects" value="slc.apps.bootloaders.bootloader_storage_external_single_series_2.matter_bootloader_external_series_2.slcp slc.apps.zigbee_light.thread.matter_thread_soc_zigbee_light_freertos.slcp"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_dishwasher_app_freertos" label="Matter Thread - SoC Dishwasher FreeRTOS" description="Demonstrates a sample implementation of a Matter over Thread dishwasher app">
+    <properties key="namespace" value="template.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.dishwasher_app.thread.matter_thread_soc_dishwasher_app_freertos.slcp"/>
+    <properties key="projectFilePaths" value="slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_freertos.slcp"/>
+    <properties key="readmeFiles" value="slc/apps/dishwasher_app/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd1019a brd2601b brd2608a brd2703a brd2704a brd2709a brd2719a brd4116a brd4117a brd4118a brd4120a brd4121a brd4186c brd4187c brd4316a brd4317a brd4318a brd4319a brd4337a brd4350a brd4351a brd4407a brd4408a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*efr32mg24a010f1536gm40.* .*efr32mg24a010f1536gm48.* .*efr32mg24a010f1536im40.* .*efr32mg24a010f1536im48.* .*efr32mg24a020f1536gm40.* .*efr32mg24a020f1536gm48.* .*efr32mg24a020f1536im40.* .*efr32mg24a020f1536im48.* .*efr32mg24a110f1536gm48.* .*efr32mg24a111f1536gm48.* .*efr32mg24a120f1536gm48.* .*efr32mg24a121f1536gm48.* .*efr32mg24a410f1536im40.* .*efr32mg24a410f1536im48.* .*efr32mg24a420f1536im40.* .*efr32mg24a420f1536im48.* .*efr32mg24a610f1536im40.* .*efr32mg24a620f1536im40.* .*efr32mg24b010f1536im40.* .*efr32mg24b010f1536im48.* .*efr32mg24b020f1536im40.* .*efr32mg24b020f1536im48.* .*efr32mg24b110f1536gm48.* .*efr32mg24b110f1536im48.* .*efr32mg24b120f1536im48.* .*efr32mg24b210f1536im40.* .*efr32mg24b210f1536im48.* .*efr32mg24b220f1536im48.* .*efr32mg24b310f1536im48.* .*efr32mg24b610f1536im40.* .*efr32mg26b211f2048im68.* .*efr32mg26b211f3200im48.* .*efr32mg26b221f2048im68.* .*efr32mg26b221f3200im48.* .*efr32mg26b311f3200il136.* .*efr32mg26b410f3200im48.* .*efr32mg26b410f3200im68.* .*efr32mg26b411f3200im48.* .*efr32mg26b411f3200im68.* .*efr32mg26b420f3200im48.* .*efr32mg26b420f3200im68.* .*efr32mg26b421f3200im48.* .*efr32mg26b421f3200im68.* .*efr32mg26b510f3200il136.* .*efr32mg26b510f3200im48.* .*efr32mg26b510f3200im68.* .*efr32mg26b511f3200il136.* .*efr32mg26b511f3200im48.* .*efr32mg26b511f3200im68.* .*efr32mg26b520f3200im48.* .*efr32mg26b520f3200im68.* .*efr32mg26b521f3200im48.* .*efr32mg26b521f3200im68.* .*efr32mg26b610f3200im48.* .*efr32mg26b611f2048im48.* .*mgm240l022rnf.* .*mgm240l022vif.* .*mgm240l022vnf.* .*mgm240la22uif.* .*mgm240la22vif.* .*mgm240ld22vif.* .*mgm240pa22vna.* .*mgm240pa32vna.* .*mgm240pa32vnn.* .*mgm240pb22vna.* .*mgm240pb32vna.* .*mgm240pb32vnn.* .*mgm240sa22vna.* .*mgm240sb22vna.* .*mgm240sd22vna.* .*mgm260pb22vna.* .*mgm260pb32vna.* .*mgm260pb32vnn.* .*mgm260pd22vna.* .*mgm260pd32vna.* .*mgm260pd32vnn.* .*simg301m103lih.* .*simg301m103wih.* .*simg301m104lgh.* .*simg301m104lgl.* .*simg301m104lih.* .*simg301m104lil.* .*simg301m104xil.* .*simg301m113wih.* .*simg301m114kgh.* .*simg301m114kih.* .*simg301m114lgh.* .*simg301m114lih.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_dishwasher_app_series_2_freertos" label="Matter Thread - SoC Dishwasher with external Bootloader FreeRTOS" description="Demonstrates a sample implementation of a Matter over Thread dishwasher app with external bootloader">
+    <properties key="namespace" value="template.solution.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.dishwasher_app.thread.matter_thread_soc_dishwasher_app_series_2_freertos.slcw"/>
+    <properties key="projectFilePaths" value="slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_series_2_freertos.slcw"/>
+    <properties key="readmeFiles" value="slc/apps/dishwasher_app/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd2601b brd2608a brd4116a brd4117a brd4118a brd4120a brd4121a brd4186c brd4187c brd4316a brd4317a brd4318a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*efr32mg24a010f1536gm40.* .*efr32mg24a010f1536gm48.* .*efr32mg24a010f1536im40.* .*efr32mg24a010f1536im48.* .*efr32mg24a020f1536gm40.* .*efr32mg24a020f1536gm48.* .*efr32mg24a020f1536im40.* .*efr32mg24a020f1536im48.* .*efr32mg24a110f1536gm48.* .*efr32mg24a111f1536gm48.* .*efr32mg24a120f1536gm48.* .*efr32mg24a121f1536gm48.* .*efr32mg24a410f1536im40.* .*efr32mg24a410f1536im48.* .*efr32mg24a420f1536im40.* .*efr32mg24a420f1536im48.* .*efr32mg24a610f1536im40.* .*efr32mg24a620f1536im40.* .*efr32mg24b010f1536im40.* .*efr32mg24b010f1536im48.* .*efr32mg24b020f1536im40.* .*efr32mg24b020f1536im48.* .*efr32mg24b110f1536gm48.* .*efr32mg24b110f1536im48.* .*efr32mg24b120f1536im48.* .*efr32mg24b210f1536im40.* .*efr32mg24b210f1536im48.* .*efr32mg24b220f1536im48.* .*efr32mg24b310f1536im48.* .*efr32mg24b610f1536im40.* .*efr32mg26b211f2048im68.* .*efr32mg26b211f3200im48.* .*efr32mg26b221f2048im68.* .*efr32mg26b221f3200im48.* .*efr32mg26b311f3200il136.* .*efr32mg26b410f3200im48.* .*efr32mg26b410f3200im68.* .*efr32mg26b411f3200im48.* .*efr32mg26b411f3200im68.* .*efr32mg26b420f3200im48.* .*efr32mg26b420f3200im68.* .*efr32mg26b421f3200im48.* .*efr32mg26b421f3200im68.* .*efr32mg26b510f3200il136.* .*efr32mg26b510f3200im48.* .*efr32mg26b510f3200im68.* .*efr32mg26b511f3200il136.* .*efr32mg26b511f3200im48.* .*efr32mg26b511f3200im68.* .*efr32mg26b520f3200im48.* .*efr32mg26b520f3200im68.* .*efr32mg26b521f3200im48.* .*efr32mg26b521f3200im68.* .*efr32mg26b610f3200im48.* .*efr32mg26b611f2048im48.* .*mgm240l022rnf.* .*mgm240l022vif.* .*mgm240l022vnf.* .*mgm240la22uif.* .*mgm240la22vif.* .*mgm240ld22vif.* .*mgm240pa22vna.* .*mgm240pa32vna.* .*mgm240pa32vnn.* .*mgm240pb22vna.* .*mgm240pb32vna.* .*mgm240pb32vnn.* .*mgm240sa22vna.* .*mgm240sb22vna.* .*mgm240sd22vna.* .*mgm260pb22vna.* .*mgm260pb32vna.* .*mgm260pb32vnn.* .*mgm260pd22vna.* .*mgm260pd32vna.* .*mgm260pd32vnn.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="solutionProjects" value="slc.apps.bootloaders.bootloader_storage_external_single_series_2.matter_bootloader_external_series_2.slcp slc.apps.dishwasher_app.thread.matter_thread_soc_dishwasher_app_freertos.slcp"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_dishwasher_app_series_2_internal_freertos" label="Matter Thread - SoC Dishwasher with internal Bootloader FreeRTOS" description="Demonstrates a sample implementation of a Matter over Thread dishwasher app with internal bootloader">
+    <properties key="namespace" value="template.solution.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.dishwasher_app.thread.matter_thread_soc_dishwasher_app_series_2_internal_freertos.slcw"/>
+    <properties key="projectFilePaths" value="slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_series_2_internal_freertos.slcw"/>
+    <properties key="readmeFiles" value="slc/apps/dishwasher_app/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd2703a brd2704a brd2709a brd4319a brd4337a brd4350a brd4351a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*efr32mg24a010f1536gm40.* .*efr32mg24a010f1536gm48.* .*efr32mg24a010f1536im40.* .*efr32mg24a010f1536im48.* .*efr32mg24a020f1536gm40.* .*efr32mg24a020f1536gm48.* .*efr32mg24a020f1536im40.* .*efr32mg24a020f1536im48.* .*efr32mg24a110f1536gm48.* .*efr32mg24a111f1536gm48.* .*efr32mg24a120f1536gm48.* .*efr32mg24a121f1536gm48.* .*efr32mg24a410f1536im40.* .*efr32mg24a410f1536im48.* .*efr32mg24a420f1536im40.* .*efr32mg24a420f1536im48.* .*efr32mg24a610f1536im40.* .*efr32mg24a620f1536im40.* .*efr32mg24b010f1536im40.* .*efr32mg24b010f1536im48.* .*efr32mg24b020f1536im40.* .*efr32mg24b020f1536im48.* .*efr32mg24b110f1536gm48.* .*efr32mg24b110f1536im48.* .*efr32mg24b120f1536im48.* .*efr32mg24b210f1536im40.* .*efr32mg24b210f1536im48.* .*efr32mg24b220f1536im48.* .*efr32mg24b310f1536im48.* .*efr32mg24b610f1536im40.* .*efr32mg26b211f2048im68.* .*efr32mg26b211f3200im48.* .*efr32mg26b221f2048im68.* .*efr32mg26b221f3200im48.* .*efr32mg26b311f3200il136.* .*efr32mg26b410f3200im48.* .*efr32mg26b410f3200im68.* .*efr32mg26b411f3200im48.* .*efr32mg26b411f3200im68.* .*efr32mg26b420f3200im48.* .*efr32mg26b420f3200im68.* .*efr32mg26b421f3200im48.* .*efr32mg26b421f3200im68.* .*efr32mg26b510f3200il136.* .*efr32mg26b510f3200im48.* .*efr32mg26b510f3200im68.* .*efr32mg26b511f3200il136.* .*efr32mg26b511f3200im48.* .*efr32mg26b511f3200im68.* .*efr32mg26b520f3200im48.* .*efr32mg26b520f3200im68.* .*efr32mg26b521f3200im48.* .*efr32mg26b521f3200im68.* .*efr32mg26b610f3200im48.* .*efr32mg26b611f2048im48.* .*mgm240l022rnf.* .*mgm240l022vif.* .*mgm240l022vnf.* .*mgm240la22uif.* .*mgm240la22vif.* .*mgm240ld22vif.* .*mgm240pa22vna.* .*mgm240pa32vna.* .*mgm240pa32vnn.* .*mgm240pb22vna.* .*mgm240pb32vna.* .*mgm240pb32vnn.* .*mgm240sa22vna.* .*mgm240sb22vna.* .*mgm240sd22vna.* .*mgm260pb22vna.* .*mgm260pb32vna.* .*mgm260pb32vnn.* .*mgm260pd22vna.* .*mgm260pd32vna.* .*mgm260pd32vnn.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="solutionProjects" value="slc.apps.bootloaders.bootloader_storage_internal_single_series_2.matter_bootloader_internal_series_2.slcp slc.apps.dishwasher_app.thread.matter_thread_soc_dishwasher_app_freertos.slcp"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_thread_soc_dishwasher_app_series_3_freertos" label="Matter Thread - SoC Dishwasher with internal Bootloader FreeRTOS" description="Demonstrates a sample implementation of a Matter over Thread dishwasher app with internal bootloader">
+    <properties key="namespace" value="template.solution.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.dishwasher_app.thread.matter_thread_soc_dishwasher_app_series_3_freertos.slcw"/>
+    <properties key="projectFilePaths" value="slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_series_3_freertos.slcw"/>
+    <properties key="readmeFiles" value="slc/apps/dishwasher_app/thread/README.md"/>
+    <properties key="boardCompatibility" value="brd1019a brd2719a brd4407a brd4408a com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*simg301m103lih.* .*simg301m103wih.* .*simg301m104lgh.* .*simg301m104lgl.* .*simg301m104lih.* .*simg301m104lil.* .*simg301m104xil.* .*simg301m113wih.* .*simg301m114kgh.* .*simg301m114kih.* .*simg301m114lgh.* .*simg301m114lih.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="solutionProjects" value="slc.apps.bootloaders.bootloader_storage_single_4096k_series_3.matter_bootloader_internal_series_3.slcp slc.apps.dishwasher_app.thread.matter_thread_soc_dishwasher_app_freertos.slcp"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_wifi_soc_dishwasher_app_freertos" label="Matter WiFi - SoC Dishwasher FreeRTOS" description="Demonstrates a sample implementation of a Matter over Wi-Fi dishwasher app">
+    <properties key="namespace" value="template.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.dishwasher_app.wifi.matter_wifi_soc_dishwasher_app_freertos.slcp"/>
+    <properties key="projectFilePaths" value="slc/apps/dishwasher_app/wifi/matter_wifi_soc_dishwasher_app_freertos.slcp"/>
+    <properties key="readmeFiles" value="slc/apps/dishwasher_app/wifi/README.md"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
+  <descriptors name="matter_wifi_soc_dishwasher_app_freertos_solution" label="Matter WiFi - SoC Dishwasher FreeRTOS" description="Demonstrates a sample implementation of a Matter over Wi-Fi dishwasher app">
+    <properties key="namespace" value="template.solution.uc"/>
+    <properties key="keywords" value="Matter"/>
+    <properties key="solutionReferenceId" value="slc.apps.dishwasher_app.wifi.matter_wifi_soc_dishwasher_app_freertos.slcw"/>
+    <properties key="projectFilePaths" value="slc/apps/dishwasher_app/wifi/matter_wifi_soc_dishwasher_app_freertos.slcw"/>
+    <properties key="readmeFiles" value="slc/apps/dishwasher_app/wifi/README.md"/>
+    <properties key="boardCompatibility" value="brd2605a brd2708a brd2911a brd4338a brd4342a brd4343a brd4343c com.silabs.board.none"/>
+    <properties key="partCompatibility" value=".*siwg917m100mgtba.* .*siwg917m100xntba.* .*siwg917m111mgtba.* .*siwg917m111xgtba.* .*siwg917y111mgab.* .*siwg917y111mgaba.* .*siwg917y111mgaxa.* .*siwg917y111mgnba.* .*siwg917y111mgnxa.* .*siwg917y121mgaba.* .*siwg917y121mgaxa.* .*siwg917y121mgnb.* .*siwg917y121mgnba.* .*siwg917y121mgnxa.*"/>
+    <properties key="ideCompatibility" value="generic-template makefile-ide simplicity-ide visual-studio-code visual-studio-code-cmake"/>
+    <properties key="toolchainCompatibility" value="gcc"/>
+    <properties key="category" value="Matter Application"/>
+    <properties key="quality" value="PRODUCTION"/>
+    <properties key="stockConfigCompatibility" value="com.silabs.ss.framework.project.toolchain.core.default"/>
+    <properties key="filters" value="Difficulty|Advanced Type|SoC\ Project Wireless\ Technology|Matter"/>
+    <properties key="solutionProjects" value="slc.apps.dishwasher_app.wifi.matter_wifi_soc_dishwasher_app_freertos.slcp"/>
+    <properties key="core.hidden" value="true"/>
+  </descriptors>
 </model:MDescriptors>


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
While studio validation, all the slcp and slcw should be a part of the templates.xml as mentioned by studio team

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Adding the files

 

> - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/third_party/matter_sdk/examples/platform/silabs/matter-platform.slcp
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/code_size_sensor/thread/matter_thread_soc_code_size_sensor_freertos.slcp
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_series_3_freertos.slcw
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_freertos.slcp
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_series_2_freertos.slcw
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_series_2_internal_freertos.slcw
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/bootloaders/bootloader_storage_single_4096k_series_3/matter_bootloader_internal_series_3.slcw
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_series_2_freertos.slcw
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/dishwasher_app/wifi/matter_wifi_soc_dishwasher_app_freertos.slcw
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/dishwasher_app/wifi/matter_wifi_soc_dishwasher_app_freertos.slcp
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_series_2_freertos.slcw
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_freertos.slcp
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_series_2_internal_freertos.slcw
>  - Example slcw/slcp file is not defined in a templates.xml file - /home/chbansal/Development/bleeding_edge/staged/matter_extension/slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_series_3_freertos.slcw
> 

in matter_templates.xml with `<properties key="core.hidden" value="true"/>` so that it is not shown to the user


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
slc validate ran locally.