### PR TITLE
Script to render board and app compatibility matrix

### DIFF
--- a/slc/script/confluence_inline_styles.sh
+++ b/slc/script/confluence_inline_styles.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# Generate inline styles for board compatibility matrix HTML for Confluence compatibility.
+#
+# Replaces CSS classes with inline styles so colors, borders, and
+# headers survive Confluence's HTML sanitizer. Content is unchanged.
+#
+# Usage: confluence_inline_styles.sh INPUT_HTML OUTPUT_DIR
+# Output: OUTPUT_DIR/<stem>.confluence.html
+#
+# Example:
+#   confluence_inline_styles.sh board_compatibility_matrix.html .
 set -euo pipefail
 
 if [ "$#" -lt 2 ]; then

--- a/slc/script/confluence_inline_styles.sh
+++ b/slc/script/confluence_inline_styles.sh
@@ -27,6 +27,7 @@ stem="${base%.*}"
 out="${outdir}/${stem}.confluence.html"
 
 perl -0777 -pe '
+s/<h2>Legend<\/h2>\s*<table>.*?<\/table>//s;
 s/<table>/<table style="border-collapse:collapse;border:1px solid #999;">/g;
 s/<td class='\''compatible'\''>/<td style="border:1px solid #999;padding:4px;width:50px;text-align:center;background-color:yellow;color:black;">/g;
 s/<td class='\''incompatible'\''>/<td style="border:1px solid #999;padding:4px;width:50px;text-align:center;background-color:lightgrey;color:black;">/g;

--- a/slc/script/confluence_inline_styles.sh
+++ b/slc/script/confluence_inline_styles.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 INPUT_HTML OUTPUT_DIR"
+    exit 1
+fi
+
+in="$1"
+outdir="$2"
+
+mkdir -p "$outdir"
+
+base="$(basename "$in")"
+stem="${base%.*}"
+
+out="${outdir}/${stem}.confluence.html"
+
+perl -0777 -pe '
+s/<table>/<table style="border-collapse:collapse;border:1px solid #999;">/g;
+s/<td class='\''compatible'\''>/<td style="border:1px solid #999;padding:4px;width:50px;text-align:center;background-color:yellow;color:black;">/g;
+s/<td class='\''incompatible'\''>/<td style="border:1px solid #999;padding:4px;width:50px;text-align:center;background-color:lightgrey;color:black;">/g;
+s/<td class='\''added'\''>/<td style="border:1px solid #999;padding:4px;width:50px;text-align:center;background-color:lightgreen;color:green;">/g;
+s/<td class='\''removed'\''>/<td style="border:1px solid #999;padding:4px;width:50px;text-align:center;background-color:lightpink;color:darkred;">/g;
+s/<td class='\''first-column'\''/<td style="border:1px solid #999;padding:4px;position:sticky;left:0;background-color:white;white-space:nowrap;"/g;
+s/<th class='\''first-column-head'\''>/<th style="border:1px solid #999;padding:4px;writing-mode:horizontal-tb;z-index:1;left:0;background-color:white;">/g;
+s/<th>/<th style="border:1px solid #999;padding:4px;writing-mode:sideways-lr;text-align:left;position:sticky;top:0;background-color:white;">/g;
+s/<div class='\''sticky-left'\''>/<div style="position:sticky;left:0;display:inline-block;">/g;
+' "$in" > "$out"
+
+echo "Wrote $out"


### PR DESCRIPTION
<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
We now generate `board_compatibility_matrix.html` to render board x app compatibility matrix automatically based on slcp/slcw files with hardware compatibility tags. This will now serve as the source of truth in [Confluence page](https://confluence.silabs.com/spaces/MATTER/pages/350656518/Sample+apps+and+Boards+Matrix). 

However, Confluence omits some styling causing the table to render as text without any borders or highlighting, making it difficult to read.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Introduce `confluence_inline_styles.sh` script to process generated html and convert styling to inline styles that are preserved in Confluence. The script also removes generated legend, as this is common to all generated matrices. This was manually copied in once at the top of the confluence page. 

Will update Confluence page with high level process for how to generate and inline the html. 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Generate html locally, render in test Confluence page