### PR TITLE
[MATTER-6731] Increase the BLE LinkeLayer task stack size for series 2 in specific case

### DIFF
--- a/slc/apps/thermostat/thread/matter_thread_soc_thermostat_freertos.slcp
+++ b/slc/apps/thermostat/thread/matter_thread_soc_thermostat_freertos.slcp
@@ -74,7 +74,7 @@ requires:
   - name: matter_drivers_series_2
     condition:
       - device_series_3
-      
+
 config_file:
   - path: ../../../../third_party/matter_sdk/examples/platform/silabs/cmp/config/sl_cmp_config.h
     condition: [matter_zigbee_multiprotocol_common]
@@ -174,8 +174,13 @@ configuration:
   - name: SL_BT_RTOS_LINK_LAYER_TASK_STACK_SIZE
     value: 1088
     condition: [matter_zigbee_multiprotocol_common, device_series_2]
-    
-# CMP configs for Zigbee Matter
+    unless: [matter_ble_dmp_test]
+  - name: SL_BT_RTOS_LINK_LAYER_TASK_STACK_SIZE
+    value: 1400
+    condition:
+      [matter_zigbee_multiprotocol_common, device_series_2, matter_ble_dmp_test]
+
+  # CMP configs for Zigbee Matter
   - name: SLI_ZIGBEE_PRIMARY_NETWORK_DEVICE_TYPE
     value: SLI_ZIGBEE_NETWORK_DEVICE_TYPE_COORDINATOR_OR_ROUTER
     condition: [matter_zigbee_multiprotocol_common]
@@ -209,7 +214,7 @@ configuration:
   - name: SL_LEGACY_HAL_DISABLE_WATCHDOG
     value: 1
     condition: [matter_zigbee_multiprotocol_common]
-# series 3 requires more stack in zb stacks
+  # series 3 requires more stack in zb stacks
   - name: SL_CLI_EXAMPLE_TASK_STACK_SIZE
     value: 1500
     condition: [device_series_3, matter_zigbee_multiprotocol_common]

--- a/slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_freertos.slcp
+++ b/slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_freertos.slcp
@@ -176,8 +176,11 @@ configuration:
     condition: [device_series_3]
   - name: SL_BT_RTOS_LINK_LAYER_TASK_STACK_SIZE
     value: 1088
-    condition:
-      - device_series_2
+    condition: [device_series_2]
+    unless: [matter_ble_dmp_test]
+  - name: SL_BT_RTOS_LINK_LAYER_TASK_STACK_SIZE
+    value: 1400
+    condition: [device_series_2, matter_ble_dmp_test]
   - name: CIRCULAR_QUEUE_LEN_MAX
     value: 16
   - name: SL_MBEDTLS_PSA_ASSUME_EXCLUSIVE_BUFFERS


### PR DESCRIPTION

<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
https://jira.silabs.com/browse/MATTER-6731

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
BLE LinkLayer task crash during commissioning for Series2 CMP app built with matter_ble_dmp_test (for BLE side channel testing)

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
In that context, The BLE LinkLayer task stack size overflows and crash the app leading to failure to commision.

The fix is to bump the Stack size of that task when the following component conditions are true
- device_series_2
- matter_ble_dmp_test
- matter_zigbee_multiprotocol_common

The increase is from 1088 to 1400 bytes. 
The high watermark recorded was 1200 bytes without crash but we want to provide a bit of flexibility, unexpected cases or growth.


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Successfully commission the CMP lighting app with `matter_ble_dmp_test` and additionnaly  `matter_tracing_runtime_stats` to collect Task stats. 
Here is the result for the LinkLayer task, post commissiong, after the bump in stack size.
```
| Task Name              | State   | Prio | Stack HWM | Stack Max | CPU %  | Preempted
| Bluetooth linklayer    | Blocked | 51   | 1200      | 1392      |  3.86% |  171/3232 
```