### PR TITLE
NOJIRA : fix llvm

### DIFF
--- a/slc/build.sh
+++ b/slc/build.sh
@@ -454,11 +454,7 @@ else
 	if [ "$USE_LLVM" = true ]; then
 		# Note: When slc-cli 6.0.21 releases, need to revert back to: 
 		# cmake_configure_and_build "$OUTPUT_DIR/$CMAKE_SUBDIR" "solution" || exit 1
-		if [ "$USE_SOLUTION" = true ]; then
-			cmake_configure_and_build "$OUTPUT_DIR/${SILABS_APP}_llvm_cmake" "solution" || exit 1        
-		else
-			cmake_configure_and_build "$OUTPUT_DIR/cmake_llvm" "application" || exit 1
-		fi
+		cmake_configure_and_build "$OUTPUT_DIR/cmake_llvm" "application" || exit 1
 	else
 		if ! make all -C "$OUTPUT_DIR" -f "$MAKE_FILE" -j13; then
 			echo "ERROR: Failed to build solution"


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
SLC CLI 6.0.22 comes with path changes for cmake/llvm builds
Error: https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/28112150889/job/83242471261 
`    Building solution...
  ERROR: solution CMakeLists.txt not found at out/brd4337a/matter_thread_soc_lighting_app_series_2_internal_freertos_solution_llvm/matter_thread_soc_lighting_app_series_2_internal_freertos_llvm_cmake`

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Fix paths


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Ran ./slc/build.sh slc/apps/lighting_app/thread/matter_thread_soc_lighting_app_series_2_internal_freertos.slcw  brd4337a --output_suffix llvm --with toolchain_llvm locally to verify

./slc/build.sh slc/apps/lighting_app/thread/matter_thread_soc_lighting_app_freertos.slcp brd4187c --with toolchain_llvm for slcp