### PR TITLE
MATTER-6779: Fix code size data

### DIFF
--- a/.github/silabs-builds-mg24.json
+++ b/.github/silabs-builds-mg24.json
@@ -60,6 +60,10 @@
             },
             {
                 "boards": ["brd4187c"],
+                "arguments": ["--output_suffix nolto", "--with_app matter_no_debug", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
+            },
+            {
+                "boards": ["brd4187c"],
                 "arguments": ["--output_suffix multipan","--with_app matter_multipan_internal"]
             },
             {
@@ -75,6 +79,10 @@
             {
                 "boards": ["brd4187c"],
                 "arguments": ["--output_suffix lto", "--with_app matter_no_debug,toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
+            },
+            {
+                "boards": ["brd4187c"],
+                "arguments": ["--output_suffix nolto", "--with_app matter_no_debug", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
             }
         ],
         "multi_sensor_app" : [
@@ -95,6 +103,10 @@
             {
                 "boards": ["brd4187c"],
                 "arguments": ["--output_suffix lto", "--with_app matter_no_debug,toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
+            },
+            {
+                "boards": ["brd4187c"],
+                "arguments": ["--output_suffix nolto", "--with_app matter_no_debug", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
             }
         ],
         "platform_template": [

--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -38,12 +38,20 @@
             {
                 "boards": ["brd4338a"],
                 "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
+            },
+            {
+                "boards": ["brd4338a"],
+                "arguments": ["--output_suffix nolto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
             }
         ],
         "lock_app": [
             {
                 "boards": ["brd4338a"],
                 "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
+            },
+            {
+                "boards": ["brd4338a"],
+                "arguments": ["--output_suffix nolto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
             }
         ],
         "platform_template": [

--- a/.github/silabs-builds-sixg301.json
+++ b/.github/silabs-builds-sixg301.json
@@ -42,12 +42,20 @@
             {
                 "boards": ["brd4407a"],
                 "arguments": ["--output_suffix lto", "--with_app matter_no_debug,toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
+            },
+            {
+                "boards": ["brd4407a"],
+                "arguments": ["--output_suffix nolto", "--with_app matter_no_debug", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
             }
         ],
         "lock_app": [
             {
                 "boards": ["brd4407a"],
                 "arguments": ["--output_suffix lto", "--with_app matter_no_debug,toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
+            },
+            {
+                "boards": ["brd4407a"],
+                "arguments": ["--output_suffix nolto", "--with_app matter_no_debug", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
             }
         ],
         "zigbee_light":  [
@@ -62,6 +70,10 @@
             {
                 "boards": ["brd4407a"],
                 "arguments": ["--output_suffix lto", "--with_app matter_no_debug,toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
+            },
+            {
+                "boards": ["brd4407a"],
+                "arguments": ["--output_suffix nolto", "--with_app matter_no_debug", "--without_app matter_shell,matter_qr_code,matter_lcd,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart", "-pids application"]
             }
         ],
         "thermostat": [

--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline
         }
         stage('Coverage and Code Size') {
             when {
-                expression { env.BRANCH_NAME == "main" || env.BRANCH_NAME.startsWith("release_") || env.BRANCH_NAME == "bugfix/MATTER-6779" }
+                expression { env.BRANCH_NAME == "main" || env.BRANCH_NAME.startsWith("release_") }
             }
             parallel {
                 stage('Code Coverage & Static Code Analysis') {

--- a/jenkins_integration/Jenkinsfile
+++ b/jenkins_integration/Jenkinsfile
@@ -124,7 +124,7 @@ pipeline
         }
         stage('Coverage and Code Size') {
             when {
-                expression { env.BRANCH_NAME == "main" || env.BRANCH_NAME.startsWith("release_") }
+                expression { env.BRANCH_NAME == "main" || env.BRANCH_NAME.startsWith("release_") || env.BRANCH_NAME == "bugfix/MATTER-6779" }
             }
             parallel {
                 stage('Code Coverage & Static Code Analysis') {

--- a/jenkins_integration/jenkinsFunctions.groovy
+++ b/jenkins_integration/jenkinsFunctions.groovy
@@ -81,8 +81,10 @@ def run_code_size_analysis() {
                         echo "-lto"
                     elif [[ "$path" == *"_solution_llvm-lto/"* ]]; then
                         echo "-lto"
+                    elif [[ "$path" == *"_solution_nolto/"* ]]; then
+                        echo "-nolto"
                     else
-                        echo ""
+                        echo "-debug"
                     fi
                 }
 
@@ -157,14 +159,16 @@ def run_code_size_analysis() {
                         target_part="siwg917m111mgtba"
                     fi
                     
-                    application_name="slc-${app}-release-${family}"
                     output_file="${app}-${example_type}-${family}.json"
-                    
+
                     if [ "$options" = "-lto" ]; then
-                        : # no-op
-                    else
-                        application_name="${application_name}-nolto"
+                        application_name="slc-${app}-release-${family}"
+                    elif [ "$options" = "-nolto" ]; then
+                        application_name="slc-${app}-release-${family}-nolto"
                         output_file="${output_file%.json}-nolto.json"
+                    else
+                        application_name="slc-${app}-debug-${family}"
+                        output_file="${output_file%.json}-debug.json"
                     fi
                     
                     echo "  Running analysis:"
@@ -219,7 +223,7 @@ def run_code_size_analysis() {
                 PATTERN=""
                 for build in $CODE_SIZE_BUILDS; do
                 [ -n "$PATTERN" ] && PATTERN="${PATTERN}|"
-                PATTERN="${PATTERN}${build}/.*\\.map\\$|${build}_lto/.*\\.map\\$"
+                PATTERN="${PATTERN}${build}/.*\\.map\\$|${build}_lto/.*\\.map\\$|${build}_nolto/.*\\.map\\$"
                 done
 
                 filtered_map_files=$(echo "$map_files_found" | grep -E "$PATTERN")


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
MATTER-6779

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
In prior releases before github transition, code size tracked:
- debug => sample app with all component enable
- release nolto => `matter_no_debug` feature, minimal app without lto 
- release => minimum app with lto enabled

This logic was lost during transition and now tracks:
- debug => n/a
- release nolto => sample app with all component enable
- release => minimum app with lto enabled

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Update code size tracking to previous implementation and add nolto builds to CI which are same as lto builds without the lto component 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI with code size
https://jenkins-cbs-iot-matter.silabs.net/blue/organizations/jenkins/Matter%20Extension%20GitHub/detail/bugfix%2FMATTER-6779/2/pipeline