### PR TITLE
NOJIRA: Removing the unused defines and disabling the UART for SiWG917 low power

### DIFF
--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -114,6 +114,7 @@
                 "boards": ["brd4338a"],
                 "arguments": ["--output_suffix low-power",
                               "--with_app matter_platform_low_power",
+                              "--configuration DEBUG_UART_ENABLE:0",
                               "--without_app matter_shell,matter_qr_code,matter_lcd,matter_lcd_917SOC,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart"]
             },
             {
@@ -175,6 +176,7 @@
                 "boards": ["brd4338a"],
                 "arguments": ["--output_suffix low-power",
                               "--with matter_platform_low_power",
+                              "--configuration DEBUG_UART_ENABLE:0",
                               "--without matter_shell,matter_qr_code,matter_lcd,matter_lcd_917SOC,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart"]
             },
             {
@@ -189,6 +191,7 @@
                 "boards": ["brd4338a"],
                 "arguments": ["--output_suffix low-power",
                               "--with matter_platform_low_power",
+                              "--configuration DEBUG_UART_ENABLE:0",
                               "--without matter_shell,matter_qr_code,matter_lcd,matter_lcd_917SOC,matter_thread_cli,matter_default_lcd_config,matter_uart,matter_log_uart"]
             }
         ],

--- a/slc/component/matter-platform/low-power/matter_platform_low_power.slcc
+++ b/slc/component/matter-platform/low-power/matter_platform_low_power.slcc
@@ -11,6 +11,9 @@ metadata:
     license: Zlib
 provides:
   - name: matter_platform_low_power
+requires:
+  - name: si91x_debug_uc
+    condition: [matter_platform_siwx917]
 conflicts:
   - name: matter_shell
   - name: matter_thread_cli

--- a/slc/component/matter-platform/matter_platform_siwx917.slcc
+++ b/slc/component/matter-platform/matter_platform_siwx917.slcc
@@ -53,12 +53,6 @@ source:
 define:
   - name: SUPPORT_CPLUSPLUS
     value: 1
-  - name: SL_WFX_CONFIG_SCAN
-    value: 1
-  - name: CHIP_9117
-    value: 1
-  - name: DEBUG_UART
-    value: "1"
   - name: SL_MATTER_SIWX_WIFI_ENABLE
   - name: SL_SI91x_DUAL_INTERRUPTS_ERRATA
   - name: NVM3_LOCK_OVERRIDE

--- a/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
+++ b/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
@@ -68,11 +68,6 @@ define:
   value: 1
 - name: CHIP_9117
   value: 1
-- name: SL_WFX_CONFIG_SCAN
-  value: 1
-- name: SL_WFX_USE_SPI
-- name: RSI_WITH_OS
-- name: SL_WIFI_COMPONENT_INCLUDED
 - name: __WEAK
   value: "__attribute__((weak))"
 


### PR DESCRIPTION
**Issue Link:** 
NA

**Description of Problem/Feature:**
- There were multiple defines which were unused and not needed
- UART init on wakeup was happening increasing the power consumption.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
- Removing the defines which weren't needed anymore
- As suggested by the platform team, the `si91x_debug_uc` component and making the configuration `DEBUG_UART_ENABLE` to 0. Ticket: https://jira.silabs.com/browse/SI91X-21100

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Tested with the 917SoC, the uart init is not happening.