### PR TITLE
Use wiseconnect lto component

### DIFF
--- a/.github/silabs-builds-siwx.json
+++ b/.github/silabs-builds-siwx.json
@@ -37,7 +37,7 @@
         "lighting_app": [
             {
                 "boards": ["brd4338a"],
-                "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
+                "arguments": ["--output_suffix lto", "--with_app wiseconnect_toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
             },
             {
                 "boards": ["brd4338a"],
@@ -47,7 +47,7 @@
         "lock_app": [
             {
                 "boards": ["brd4338a"],
-                "arguments": ["--output_suffix lto", "--with_app toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
+                "arguments": ["--output_suffix lto", "--with_app wiseconnect_toolchain_gcc_lto", "--without_app matter_shell,matter_qr_code,matter_lcd"]
             },
             {
                 "boards": ["brd4338a"],


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
CI in main failing bc cherry-pick from release use `toolchain_gcc_lto`, but this was added in release branch which has not been upstreamed yet. 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Use old `wiseconnect_toolchain_gcc_lto` component instead until release -> main merge 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Local test with gcc 12.2, successfully built