### PR TITLE
Revert Logic for log

### DIFF
--- a/slc/component/matter-platform/logging/matter_log_rtt.slcc
+++ b/slc/component/matter-platform/logging/matter_log_rtt.slcc
@@ -12,5 +12,7 @@ provides:
 define:
   - name: SILABS_LOG_OUT_UART
     value: 0
+  - name: SILABS_LOG_ENABLE
+    value: 1  
 conflicts:
   - name: matter_log_uart

--- a/slc/component/matter-platform/logging/matter_log_uart.slcc
+++ b/slc/component/matter-platform/logging/matter_log_uart.slcc
@@ -16,5 +16,7 @@ requires:
 define:
   - name: SILABS_LOG_OUT_UART
     value: 1
+  - name: SILABS_LOG_ENABLE
+    value: 1    
 conflicts:
   - name: matter_log_rtt

--- a/slc/config/sl_matter_config.h
+++ b/slc/config/sl_matter_config.h
@@ -24,10 +24,10 @@
 #endif
 
 // <q SILABS_LOG_ENABLED> Enable Silabs specific log used in matter
-// <i> Default: 1
+// <i> Default: 0
 // <i> Enables Silicon Labs platform-specific logging within the Matter stack
 #ifndef SILABS_LOG_ENABLED
-#define SILABS_LOG_ENABLED 1
+#define SILABS_LOG_ENABLED 0
 #endif
 
 // <q HARD_FAULT_LOG_ENABLE> Enable hard fault logging


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
None
<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Logs can "sneak in" over RTT even if the `matter_log_rtt` component is removed.

Needs this PR to be fully fonctional but shouldn't affect default behavior. 

https://github.com/project-chip/connectedhomeip/pull/72909
<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Add the SILABS_LOG_ENABLE define inside the SLCC component for logs so that they are only enable when the slcp file actually includes the log component.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Tested locally with a series 3 device. without `matter_log_*` components no log are outputed on the device