### PR TITLE
Fix code size run failure

### DIFF
--- a/jenkins_integration/jenkinsFunctions.groovy
+++ b/jenkins_integration/jenkinsFunctions.groovy
@@ -57,6 +57,9 @@ def run_code_size_analysis() {
                             *lock_app*)
                                 app_name="lock-app"
                                 ;;
+                            *multi_sensor_app*)
+                                app_name="multi-sensor-app"
+                                ;;
                         esac
                     else
                         echo "ERROR: Could not find solution directory in path: \$path" >&2


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
NOJIRA

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
https://github.com/SiliconLabsSoftware/matter_extension/pull/896 brought in multi sensor app into code size, but did not include mapping from multi_sensor_app -> multi-sensor-app for app naming, causing a parse failure. this is needed as new app naming convention standardized on underscore rather than dash, but we need to standardize on dash in code size to have tracking with older releases. 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Add mapping for multi sensor app. 

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
CI will test, should work as it is already implemented with other apps