### PR TITLE
MATTER-6645: Moving the config files as a part of the non include folder

### DIFF
--- a/packages/matter/matter.slce.extra
+++ b/packages/matter/matter.slce.extra
@@ -1003,10 +1003,6 @@ extra_files:
   - tools/pymattertool/src/utils.py
   - upgrade.slcu
   # matter_sdk paths
-  - third_party/matter_sdk/examples/air-quality-sensor-app/silabs/config/AirQualityConfig.h
-  - third_party/matter_sdk/examples/fan-control-app/silabs/config/FanControlConfig.h
-  - third_party/matter_sdk/examples/lock-app/silabs/config/LockConfig.h
-  - third_party/matter_sdk/examples/rangehood-app/silabs/config/RangeHoodConfig.h
   - third_party/matter_sdk/src/app/AppConfig.h
   - third_party/matter_sdk/src/app/AttributeAccessInterface.h
   - third_party/matter_sdk/src/app/AttributeAccessInterfaceCache.h
@@ -3450,8 +3446,5 @@ extra_files:
   - third_party/matter_sdk/src/app/zap-templates/zcl/zcl.xsd
   - third_party/matter_sdk/src/app/zap_cluster_list.json
   - third_party/matter_sdk/src/app/zap_cluster_list.py
-  - third_party/matter_sdk/src/lwip/silabs/config/lwipopts.h
-  - third_party/matter_sdk/src/platform/silabs/efr32/config/efr32-chip-mbedtls-config.h
-  - third_party/matter_sdk/src/platform/silabs/efr32/config/efr32-psa-crypto-config.h
 git_extra_files:
 git_path_mapping:

--- a/packages/matter/matter.slce.extra
+++ b/packages/matter/matter.slce.extra
@@ -1003,6 +1003,10 @@ extra_files:
   - tools/pymattertool/src/utils.py
   - upgrade.slcu
   # matter_sdk paths
+  - third_party/matter_sdk/examples/air-quality-sensor-app/silabs/config/AirQualityConfig.h
+  - third_party/matter_sdk/examples/fan-control-app/silabs/config/FanControlConfig.h
+  - third_party/matter_sdk/examples/lock-app/silabs/config/LockConfig.h
+  - third_party/matter_sdk/examples/rangehood-app/silabs/config/RangeHoodConfig.h
   - third_party/matter_sdk/src/app/AppConfig.h
   - third_party/matter_sdk/src/app/AttributeAccessInterface.h
   - third_party/matter_sdk/src/app/AttributeAccessInterfaceCache.h
@@ -3446,5 +3450,8 @@ extra_files:
   - third_party/matter_sdk/src/app/zap-templates/zcl/zcl.xsd
   - third_party/matter_sdk/src/app/zap_cluster_list.json
   - third_party/matter_sdk/src/app/zap_cluster_list.py
+  - third_party/matter_sdk/src/lwip/silabs/config/lwipopts.h
+  - third_party/matter_sdk/src/platform/silabs/efr32/config/efr32-chip-mbedtls-config.h
+  - third_party/matter_sdk/src/platform/silabs/efr32/config/efr32-psa-crypto-config.h
 git_extra_files:
 git_path_mapping:

--- a/slc/component/matter-clusters/matter_air_quality.slcc
+++ b/slc/component/matter-clusters/matter_air_quality.slcc
@@ -23,7 +23,7 @@ include:
       - path: CodegenIntegration.h
         unless: [matter_code_driven_dm]
 config_file:
-  - path: third_party/matter_sdk/examples/air-quality-sensor-app/silabs/include/AirQualityConfig.h
+  - path: third_party/matter_sdk/examples/air-quality-sensor-app/silabs/config/AirQualityConfig.h
     file_id: matter_air_quality_config
 template_contribution:
   - name: component_catalog

--- a/slc/component/matter-core-sdk/efr32.slcc
+++ b/slc/component/matter-core-sdk/efr32.slcc
@@ -99,7 +99,6 @@ include:
     file_list:
       - path: lwipopts-siwx.h
       - path: lwippools.h
-      - path: lwipopts.h
   - path: third_party/matter_sdk/examples/platform/silabs
     file_list:
     -   path: board_config.h
@@ -149,8 +148,6 @@ include:
     file_list:
       - path: Efr32PsaOperationalKeystore.h
       - path: Efr32OpaqueKeypair.h
-      - path: efr32-psa-crypto-config.h
-      - path: efr32-chip-mbedtls-config.h
       - path: BLEChannel.h
   - path: third_party/matter_sdk/src/platform/OpenThread
     file_list:

--- a/slc/component/matter-core-sdk/efr32_wifi.slcc
+++ b/slc/component/matter-core-sdk/efr32_wifi.slcc
@@ -100,7 +100,6 @@ include:
   file_list:
   - path: lwipopts-siwx.h
   - path: lwippools.h
-  - path: lwipopts.h
 - path: third_party/matter_sdk/examples/platform/silabs
   file_list:
   - path: board_config.h
@@ -129,8 +128,6 @@ include:
   file_list:
   - path: Efr32PsaOperationalKeystore.h
   - path: Efr32OpaqueKeypair.h
-  - path: efr32-psa-crypto-config.h
-  - path: efr32-chip-mbedtls-config.h
   - path: BLEChannel.h
 
 - path: third_party/matter_sdk/src/platform/silabs

--- a/slc/component/matter-core-sdk/siwx917.slcc
+++ b/slc/component/matter-core-sdk/siwx917.slcc
@@ -101,7 +101,6 @@ include:
   file_list:
   - path: lwipopts-siwx.h
   - path: lwippools.h
-  - path: lwipopts.h
 - path: third_party/matter_sdk/examples/platform/silabs
   file_list:
   - path: board_config.h

--- a/slc/component/matter-examples/matter_fan_control_app.slcc
+++ b/slc/component/matter-examples/matter_fan_control_app.slcc
@@ -15,7 +15,7 @@ template_file:
   - path: third_party/matter_sdk/examples/fan-control-app/silabs/src/AppTask.cpp
 
 config_file:
-  - path: third_party/matter_sdk/examples/fan-control-app/silabs/include/FanControlConfig.h
+  - path: third_party/matter_sdk/examples/fan-control-app/silabs/config/FanControlConfig.h
     file_id: fan_control_config
 provides:
   - name: matter_fan_control_app

--- a/slc/component/matter-examples/matter_lock.slcc
+++ b/slc/component/matter-examples/matter_lock.slcc
@@ -15,7 +15,7 @@ template_file:
   - path: third_party/matter_sdk/examples/lock-app/silabs/src/AppTask.cpp
 
 config_file:
-  - path: third_party/matter_sdk/examples/lock-app/silabs/include/LockConfig.h
+  - path: third_party/matter_sdk/examples/lock-app/silabs/config/LockConfig.h
     file_id: matter_lock_config
 provides:
   - name: matter_lock

--- a/slc/component/matter-examples/matter_rangehood.slcc
+++ b/slc/component/matter-examples/matter_rangehood.slcc
@@ -15,5 +15,5 @@ template_file:
   - path: third_party/matter_sdk/examples/rangehood-app/silabs/include/AppTaskImpl.h
   - path: third_party/matter_sdk/examples/rangehood-app/silabs/src/AppTask.cpp
 config_file:
-  - path: third_party/matter_sdk/examples/rangehood-app/silabs/include/RangeHoodConfig.h
+  - path: third_party/matter_sdk/examples/rangehood-app/silabs/config/RangeHoodConfig.h
     file_id: rangehood_config

--- a/slc/component/matter-platform/crypto/matter_crypto.slcc
+++ b/slc/component/matter-platform/crypto/matter_crypto.slcc
@@ -60,9 +60,9 @@ recommends:
 config_file:
   - path: slc/config/sli_psa_builtin_config.h
     file_id: sli_psa_builtin_config
-  - path: third_party/matter_sdk/src/platform/silabs/efr32/efr32-chip-mbedtls-config.h
+  - path: third_party/matter_sdk/src/platform/silabs/efr32/config/efr32-chip-mbedtls-config.h
     file_id: efr32-chip-mbedtls-config
-  - path: third_party/matter_sdk/src/platform/silabs/efr32/efr32-psa-crypto-config.h
+  - path: third_party/matter_sdk/src/platform/silabs/efr32/config/efr32-psa-crypto-config.h
     file_id: efr32-psa-crypto-config
 
 define:

--- a/slc/component/matter-platform/matter_platform_siwx917.slcc
+++ b/slc/component/matter-platform/matter_platform_siwx917.slcc
@@ -8,7 +8,7 @@ metadata:
   sbom:
     license: Zlib
 config_file:
-  - path: third_party/matter_sdk/src/lwip/silabs/lwipopts.h
+  - path: third_party/matter_sdk/src/lwip/silabs/config/lwipopts.h
     override:
       component: "wifi_resources"
       file_id: lwipopts

--- a/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
+++ b/slc/component/matter-wifi/917-ncp/siwx917_ncp.slcc
@@ -9,7 +9,7 @@ metadata:
   sbom:
     license: Zlib
 config_file:
-  - path: third_party/matter_sdk/src/lwip/silabs/lwipopts.h
+  - path: third_party/matter_sdk/src/lwip/silabs/config/lwipopts.h
     override:
       component: "wifi_resources"
       file_id: lwipopts

--- a/slc/component/matter-wifi/matter_dual_stack.slcc
+++ b/slc/component/matter-wifi/matter_dual_stack.slcc
@@ -28,7 +28,6 @@ requires:
 include:
   - path: third_party/matter_sdk/src/lwip/silabs
     file_list:
-      - path: lwipopts.h
       - path: lwipopts-siwx.h
       - path: arch/cc.h
       - path: arch/perf.h

--- a/slc/component/matter-wifi/matter_lwip.slcc
+++ b/slc/component/matter-wifi/matter_lwip.slcc
@@ -24,7 +24,6 @@ requires:
 include:
   - path: third_party/matter_sdk/src/lwip/silabs
     file_list:
-      - path: lwipopts.h
       - path: lwipopts-siwx.h
       - path: arch/cc.h
       - path: arch/perf.h

--- a/slc/component/matter-wifi/matter_lwip_modified.slcc
+++ b/slc/component/matter-wifi/matter_lwip_modified.slcc
@@ -19,7 +19,6 @@ provides:
 include:
   - path: third_party/matter_sdk/src/lwip/silabs
     file_list:
-      - path: lwipopts.h
       - path: lwipopts-siwx.h
       - path: arch/cc.h
       - path: arch/perf.h

--- a/slc/script/validate_extension.py
+++ b/slc/script/validate_extension.py
@@ -13,8 +13,11 @@ Ownership model:
 
 Per section policy:
   Config File on Include Path
-    Path based on the config file path embedded in the finding.
-    MATTER_FAILURE if matter owned, SUBMODULE otherwise.
+    Ownership from the extension/component id in the finding (e.g.
+    %extension-silabs.matter%), not the config header path. Header paths are
+    often under third_party/matter_sdk, which would incorrectly classify as
+    SUBMODULE. MATTER_FAILURE for Matter extension findings, otherwise path
+    based.
 
   Any other section (including SDK warnings, Studio SDK Metadata)
     Fully enforced, path based: SUBMODULE if third_party/, otherwise
@@ -45,6 +48,13 @@ _THIRD_PARTY_ROOT = _REPO_ROOT / "third_party"
 # Finding categories
 MATTER_FAILURE = "matter-failure"
 SUBMODULE = "submodule"
+
+# Matches Matter extension component ids in slc validate findings, e.g.
+#   %extension-silabs.matter%matter_lock
+#   (affects silabs.matter.matter_shell)
+_MATTER_EXTENSION_FINDING = re.compile(
+    r"%extension-silabs\.matter%|\bsilabs\.matter\."
+)
 
 def _parse_sections(output: str) -> Dict[str, List[str]]:
     """
@@ -161,6 +171,14 @@ def _classify_finding(section: str, finding: str, filepath: Optional[str] = None
     filepath: for SDK warnings the path is known separately, pass it explicitly.
               For all other sections it is extracted from the finding string.
     """
+    # Config headers often live under third_party/matter_sdk; attribute ownership
+    # from the extension/component id so Matter findings fail CI.
+    if section == "Config File on Include Path":
+        if _MATTER_EXTENSION_FINDING.search(finding):
+            return MATTER_FAILURE
+        path_str = filepath if filepath is not None else _extract_path_from_finding(finding)
+        return _path_based(path_str)
+
     path_str = filepath if filepath is not None else _extract_path_from_finding(finding)
     return _path_based(path_str)
 


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
MATTER-6645

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
slc validate was failing since the config files were part of include list causing duplicates

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Moving the config_files to config folder which won't be a part of the list.


```
- %extension-silabs.matter%matter_air_quality - third_party/matter_sdk/examples/air-quality-sensor-app/silabs/include/AirQualityConfig.h (affects silabs.matter.matter_lcd, silabs.matter.matter_lcd_917SOC)`
- %extension-silabs.matter%matter_crypto - third_party/matter_sdk/src/platform/silabs/efr32/efr32-chip-mbedtls-config.h (affects silabs.matter.efr32, silabs.matter.efr32_wifi, silabs.matter.libopenthread_efr32,...)
- %extension-silabs.matter%matter_crypto - third_party/matter_sdk/src/platform/silabs/efr32/efr32-psa-crypto-config.h (affects silabs.matter.efr32, silabs.matter.efr32_wifi, silabs.matter.libopenthread_efr32,...)
- %extension-silabs.matter%matter_fan_control_app - third_party/matter_sdk/examples/fan-control-app/silabs/include/FanControlConfig.h (affects silabs.matter.matter_lcd, silabs.matter.matter_lcd_917SOC)
- %extension-silabs.matter%matter_lock - third_party/matter_sdk/examples/lock-app/silabs/include/LockConfig.h (affects silabs.matter.matter_shell)
- %extension-silabs.matter%matter_platform_siwx917 - third_party/matter_sdk/src/lwip/silabs/lwipopts.h (affects silabs.matter.efr32, silabs.matter.efr32_wifi, silabs.matter.matter_dual_stack,...)
- %extension-silabs.matter%matter_rangehood - third_party/matter_sdk/examples/rangehood-app/silabs/include/RangeHoodConfig.h (affects silabs.matter.matter_lcd, silabs.matter.matter_lcd_917SOC)
- %extension-silabs.matter%siwx917_ncp - third_party/matter_sdk/src/lwip/silabs/lwipopts.h (affects silabs.matter.efr32, silabs.matter.efr32_wifi, silabs.matter.matter_dual_stack,...)
```


<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
slc validate locally and CI