### PR TITLE
MATTER-6843 : Fix llvm

### DIFF
--- a/jenkins_integration/artifacts/artifact_processor.py
+++ b/jenkins_integration/artifacts/artifact_processor.py
@@ -488,23 +488,24 @@ def _upload_wifi_firmware_files(board_path, board_folder, branch_name, build_num
                 upload_to_ubai(fw_file_path, ubai_app_name, board_folder, branch_name, build_number)
 
 
-def _upload_board_artifacts(board_id, board_path, branch_name, build_number):
+def _upload_board_artifacts(board_dir_name, board_path, branch_name, build_number):
     """
     Upload board-specific artifacts to UBAI.
 
     Args:
-        board_id (str): Board identifier
+        board_dir_name (str): Out directory name (may include part suffix)
         board_path (str): Path to the board directory
         branch_name (str): Branch name for upload
         build_number (int): Build number for upload
     """
-    board_id_upper = board_id.upper()
-    print(f"Processing board ID: {board_id_upper}")
+    # Series 3 out dirs use board_part: CMake writes -Wl,-Map=<path> and clang's -Wl, splits on commas.
+    board_id = board_dir_name.upper().replace(",", "_").split("_")[0]
+    print(f"Processing board directory: {board_dir_name} -> UBAI board ID: {board_id}")
     for app_name_folder in os.listdir(board_path):
         app_name_path = os.path.join(board_path, app_name_folder)
         print(f"Sample App Path: {app_name_path}")
         if os.path.isdir(app_name_path):
-            _process_board_app(app_name_folder, app_name_path, board_id_upper, branch_name, build_number)
+            _process_board_app(app_name_folder, app_name_path, board_id, branch_name, build_number)
 
 
 def _process_board_app(app_name_folder, app_name_path, board_id, branch_name, build_number):
@@ -514,13 +515,11 @@ def _process_board_app(app_name_folder, app_name_path, board_id, branch_name, bu
     Args:
         app_name_folder (str): Application folder name
         app_name_path (str): Path to the application directory
-        board_id (str): Board identifier
+        board_id (str): Normalized UBAI board identifier
         branch_name (str): Branch name for upload
         build_number (int): Build number for upload
     """
     try:
-        # Series 3 out dirs use board_part (build.sh); older artifacts used board,part.
-        board_id = board_id.replace(",", "_").split("_")[0]
         ubai_app_name = determine_ubai_app_name(app_name_folder)
         artifact_solution_folder = os.path.join(app_name_path, 'artifact')
         if os.path.exists(artifact_solution_folder) and os.path.isdir(artifact_solution_folder):

--- a/jenkins_integration/artifacts/artifact_processor.py
+++ b/jenkins_integration/artifacts/artifact_processor.py
@@ -519,7 +519,8 @@ def _process_board_app(app_name_folder, app_name_path, board_id, branch_name, bu
         build_number (int): Build number for upload
     """
     try:
-        board_id = board_id.split(",")[0] # Handles 1019A 3MB BRD1019A,SIMG301M113WIH
+        # Series 3 out dirs use board_part (build.sh); older artifacts used board,part.
+        board_id = board_id.replace(",", "_").split("_")[0]
         ubai_app_name = determine_ubai_app_name(app_name_folder)
         artifact_solution_folder = os.path.join(app_name_path, 'artifact')
         if os.path.exists(artifact_solution_folder) and os.path.isdir(artifact_solution_folder):

--- a/slc/build.sh
+++ b/slc/build.sh
@@ -453,9 +453,7 @@ elif [ "$GENERATE_BOOTLOADER" = false ] && [ "$GENERATE_APPLICATION" = true ]; t
 else
 	echo "Building solution..."
 	if [ "$USE_LLVM" = true ]; then
-		# Note: When slc-cli 6.0.21 releases, need to revert back to: 
-		# cmake_configure_and_build "$OUTPUT_DIR/$CMAKE_SUBDIR" "solution" || exit 1
-		cmake_configure_and_build "$OUTPUT_DIR/cmake_llvm" "application" || exit 1
+		cmake_configure_and_build "$OUTPUT_DIR/$CMAKE_SUBDIR" "solution" || exit 1
 	else
 		if ! make all -C "$OUTPUT_DIR" -f "$MAKE_FILE" -j13; then
 			echo "ERROR: Failed to build solution"

--- a/slc/build.sh
+++ b/slc/build.sh
@@ -149,7 +149,8 @@ fi
 SILABS_APP_PATH=$1
 SILABS_BOARD=$2
 CONFIG_ARGS=""
-BRD_ONLY=$(echo "$SILABS_BOARD" | cut -f1 -d";")
+# Sanitize for filesystem path: Series 3 boards use board,part (comma breaks -Wl,-Map=).
+BRD_ONLY=$(echo "$SILABS_BOARD" | cut -f1 -d";" | tr ',' '_')
 if [ -z "$POST_BUILD_EXE" ]; then
 	export POST_BUILD_EXE=$(which commander)
 fi

--- a/slc/build.sh
+++ b/slc/build.sh
@@ -149,7 +149,7 @@ fi
 SILABS_APP_PATH=$1
 SILABS_BOARD=$2
 CONFIG_ARGS=""
-# Sanitize for filesystem path: Series 3 boards use board,part (comma breaks -Wl,-Map=).
+# tr converts board,part to board_part to avoid breaking clang builds.
 BRD_ONLY=$(echo "$SILABS_BOARD" | cut -f1 -d";" | tr ',' '_')
 if [ -z "$POST_BUILD_EXE" ]; then
 	export POST_BUILD_EXE=$(which commander)


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
[MATTER-6843](https://jira.silabs.com/browse/MATTER-6843)

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
llvm build fails as the `brd1019a,SIMG301M113WIH` folder name contain "," which cmake-llvm considers comma separated paths. 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Update the paths to use `_` instead `,`

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
 build locally
`./slc/build.sh slc/apps/light_switch_app/thread/matter_thread_soc_light_switch_app_series_3_freertos.slcw  brd1019a,SIMG301M113WIH --output_suffix llvm-sqa-lto --withtoolchain_llvm_lto`

Full Build
https://github.com/SiliconLabsSoftware/matter_extension/actions/runs/29610185694