### PR TITLE
Update SLCP and components to build without segger_rtt

### DIFF
--- a/slc/apps/air_quality_sensor_app/thread/matter_thread_soc_air_quality_sensor_app_freertos.slcp
+++ b/slc/apps/air_quality_sensor_app/thread/matter_thread_soc_air_quality_sensor_app_freertos.slcp
@@ -61,8 +61,7 @@ component:
 
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
 requires:
   # On Series 2 LCD and external flash run over USART, VCOM runs over EUSART
   # Select UART/EUART drivers based on device series

--- a/slc/apps/air_quality_sensor_app/wifi/matter_wifi_soc_air_quality_sensor_app_freertos.slcp
+++ b/slc/apps/air_quality_sensor_app/wifi/matter_wifi_soc_air_quality_sensor_app_freertos.slcp
@@ -50,8 +50,7 @@ component:
   - id: matter_relative_humidity_measurement
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_ota_requestor
   - id: matter_ota_support
   - id: matter_shell

--- a/slc/apps/closure_app/thread/matter_thread_soc_closure_app_freertos.slcp
+++ b/slc/apps/closure_app/thread/matter_thread_soc_closure_app_freertos.slcp
@@ -51,7 +51,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_test_event_trigger
+  - id: matter_test_event_trigger
   - id: matter_icd_management
 requires:
   # On Series 2 LCD and external flash run over USART, VCOM runs over EUSART

--- a/slc/apps/closure_app/thread/matter_thread_soc_closure_app_freertos.slcp
+++ b/slc/apps/closure_app/thread/matter_thread_soc_closure_app_freertos.slcp
@@ -51,8 +51,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_test_event_trigger
+    - id: matter_test_event_trigger
   - id: matter_icd_management
 requires:
   # On Series 2 LCD and external flash run over USART, VCOM runs over EUSART

--- a/slc/apps/closure_app/wifi/matter_wifi_soc_closure_app_freertos.slcp
+++ b/slc/apps/closure_app/wifi/matter_wifi_soc_closure_app_freertos.slcp
@@ -41,7 +41,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_closure
+  - id: matter_closure
   - id: matter_closure_control
   - id: matter_closure_dimension
   - id: matter_shell

--- a/slc/apps/closure_app/wifi/matter_wifi_soc_closure_app_freertos.slcp
+++ b/slc/apps/closure_app/wifi/matter_wifi_soc_closure_app_freertos.slcp
@@ -41,8 +41,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_closure
+    - id: matter_closure
   - id: matter_closure_control
   - id: matter_closure_dimension
   - id: matter_shell

--- a/slc/apps/code_size_sensor/thread/matter_thread_soc_code_size_sensor_freertos.slcp
+++ b/slc/apps/code_size_sensor/thread/matter_thread_soc_code_size_sensor_freertos.slcp
@@ -50,8 +50,7 @@ component:
   # Optional feature
   - id: rail_util_pti
   - id: matter_shell
-  - id: segger_rtt
-  - id: matter_configuration_over_swo
+    - id: matter_configuration_over_swo
   - id: matter_log_uart
   - id: matter_default_lcd_config
 

--- a/slc/apps/code_size_sensor/thread/matter_thread_soc_code_size_sensor_freertos.slcp
+++ b/slc/apps/code_size_sensor/thread/matter_thread_soc_code_size_sensor_freertos.slcp
@@ -50,7 +50,7 @@ component:
   # Optional feature
   - id: rail_util_pti
   - id: matter_shell
-    - id: matter_configuration_over_swo
+  - id: matter_configuration_over_swo
   - id: matter_log_uart
   - id: matter_default_lcd_config
 

--- a/slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_freertos.slcp
+++ b/slc/apps/dishwasher_app/thread/matter_thread_soc_dishwasher_app_freertos.slcp
@@ -56,8 +56,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
 requires:
   # On Series 2 LCD and external flash run over USART, VCOM runs over EUSART
   # Select UART/EUART drivers based on device series

--- a/slc/apps/dishwasher_app/wifi/matter_wifi_soc_dishwasher_app_freertos.slcp
+++ b/slc/apps/dishwasher_app/wifi/matter_wifi_soc_dishwasher_app_freertos.slcp
@@ -49,7 +49,7 @@ component:
   - id: matter_unit_localization
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_ota_requestor
+  - id: matter_ota_requestor
   - id: matter_ota_support
   - id: matter_default_lcd_config
   - id: matter_shell

--- a/slc/apps/dishwasher_app/wifi/matter_wifi_soc_dishwasher_app_freertos.slcp
+++ b/slc/apps/dishwasher_app/wifi/matter_wifi_soc_dishwasher_app_freertos.slcp
@@ -49,8 +49,7 @@ component:
   - id: matter_unit_localization
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_ota_requestor
+    - id: matter_ota_requestor
   - id: matter_ota_support
   - id: matter_default_lcd_config
   - id: matter_shell

--- a/slc/apps/evse_app/thread/matter_thread_soc_evse_app_freertos.slcp
+++ b/slc/apps/evse_app/thread/matter_thread_soc_evse_app_freertos.slcp
@@ -59,8 +59,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
 requires:
   # On Series 2 LCD and external flash run over USART, VCOM runs over EUSART
   # Select UART/EUART drivers based on device series

--- a/slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcp
+++ b/slc/apps/evse_app/wifi/matter_wifi_soc_evse_app_freertos.slcp
@@ -40,8 +40,7 @@ component:
   - id: matter_network_commissioning
   - id: matter_operational_credentials
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_ota_requestor
   - id: matter_ota_support
   - id: toolchain_gcc_common

--- a/slc/apps/fan_control_app/thread/matter_thread_soc_fan_control_app_freertos.slcp
+++ b/slc/apps/fan_control_app/thread/matter_thread_soc_fan_control_app_freertos.slcp
@@ -57,8 +57,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_fan_control_app
 
 requires:

--- a/slc/apps/fan_control_app/wifi/matter_wifi_917_ncp_fan_control_app_freertos.slcp
+++ b/slc/apps/fan_control_app/wifi/matter_wifi_917_ncp_fan_control_app_freertos.slcp
@@ -60,8 +60,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_shell
   - id: matter_log_uart
   - id: matter_lwip

--- a/slc/apps/fan_control_app/wifi/matter_wifi_soc_fan_control_app_freertos.slcp
+++ b/slc/apps/fan_control_app/wifi/matter_wifi_soc_fan_control_app_freertos.slcp
@@ -47,8 +47,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_ota_requestor
   - id: matter_ota_support
   - id: matter_shell

--- a/slc/apps/light_switch_app/thread/matter_thread_soc_light_switch_app_freertos.slcp
+++ b/slc/apps/light_switch_app/thread/matter_thread_soc_light_switch_app_freertos.slcp
@@ -63,8 +63,7 @@ component:
 
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   # ICD configurations
   - id: matter_icd_core
   - id: matter_test_event_trigger

--- a/slc/apps/light_switch_app/wifi/matter_wifi_soc_light_switch_app_freertos.slcp
+++ b/slc/apps/light_switch_app/wifi/matter_wifi_soc_light_switch_app_freertos.slcp
@@ -54,7 +54,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_ota_support
+  - id: matter_ota_support
   - id: matter_shell
   - id: matter_default_lcd_config
   # ICD configurations

--- a/slc/apps/light_switch_app/wifi/matter_wifi_soc_light_switch_app_freertos.slcp
+++ b/slc/apps/light_switch_app/wifi/matter_wifi_soc_light_switch_app_freertos.slcp
@@ -54,8 +54,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_ota_support
+    - id: matter_ota_support
   - id: matter_shell
   - id: matter_default_lcd_config
   # ICD configurations

--- a/slc/apps/lighting_app/thread/matter_thread_soc_lighting_app_freertos.slcp
+++ b/slc/apps/lighting_app/thread/matter_thread_soc_lighting_app_freertos.slcp
@@ -57,8 +57,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
 requires:
   # On Series 2 LCD and external flash run over USART, VCOM runs over EUSART
   # Select UART/EUART drivers based on device series

--- a/slc/apps/lighting_app/thread/trustzone/matter_thread_soc_lighting_app_trustzone_ns_freertos.slcp
+++ b/slc/apps/lighting_app/thread/trustzone/matter_thread_soc_lighting_app_trustzone_ns_freertos.slcp
@@ -57,8 +57,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  # TrustZone
+    # TrustZone
   - id: bootloader_interface
   - id: trustzone_nonsecure
   - id: tz_secure_key_library

--- a/slc/apps/lighting_app/wifi/matter_wifi_soc_lighting_app_freertos.slcp
+++ b/slc/apps/lighting_app/wifi/matter_wifi_soc_lighting_app_freertos.slcp
@@ -50,8 +50,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_ota_requestor
   - id: matter_ota_support
   - id: matter_power_source

--- a/slc/apps/lock_app/thread/matter_thread_soc_lock_app_freertos.slcp
+++ b/slc/apps/lock_app/thread/matter_thread_soc_lock_app_freertos.slcp
@@ -58,8 +58,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_icd_core
   - id: matter_test_event_trigger
   - id: matter_icd_management

--- a/slc/apps/lock_app/wifi/matter_wifi_917_ncp_lock_app_freertos.slcp
+++ b/slc/apps/lock_app/wifi/matter_wifi_917_ncp_lock_app_freertos.slcp
@@ -62,8 +62,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_shell
   - id: matter_icd_core
   - id: matter_test_event_trigger

--- a/slc/apps/lock_app/wifi/matter_wifi_soc_lock_app_freertos.slcp
+++ b/slc/apps/lock_app/wifi/matter_wifi_soc_lock_app_freertos.slcp
@@ -48,8 +48,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_ota_requestor
   - id: matter_ota_support
   - id: matter_lock

--- a/slc/apps/multi_sensor_app/thread/matter_thread_soc_multi_sensor_app_freertos.slcp
+++ b/slc/apps/multi_sensor_app/thread/matter_thread_soc_multi_sensor_app_freertos.slcp
@@ -59,8 +59,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_si70xx_sensor
+    - id: matter_si70xx_sensor
     condition: [hardware_board_has_si70xx]
   - id: matter_log_uart
   - id: matter_multi_sensor_app

--- a/slc/apps/multi_sensor_app/thread/matter_thread_soc_multi_sensor_app_freertos.slcp
+++ b/slc/apps/multi_sensor_app/thread/matter_thread_soc_multi_sensor_app_freertos.slcp
@@ -59,7 +59,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_si70xx_sensor
+  - id: matter_si70xx_sensor
     condition: [hardware_board_has_si70xx]
   - id: matter_log_uart
   - id: matter_multi_sensor_app

--- a/slc/apps/multi_sensor_app/wifi/matter_wifi_soc_multi_sensor_app_freertos.slcp
+++ b/slc/apps/multi_sensor_app/wifi/matter_wifi_soc_multi_sensor_app_freertos.slcp
@@ -50,8 +50,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_ota_requestor
   - id: matter_occupancy_sensor
   - id: matter_ota_support

--- a/slc/apps/onoff_plug_app/thread/matter_thread_soc_onoff_plug_app_freertos.slcp
+++ b/slc/apps/onoff_plug_app/thread/matter_thread_soc_onoff_plug_app_freertos.slcp
@@ -61,8 +61,7 @@ component:
 
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
 requires:
   # On Series 2 LCD and external flash run over USART, VCOM runs over EUSART
   # Select UART/EUART drivers based on device series

--- a/slc/apps/onoff_plug_app/wifi/matter_wifi_soc_onoff_plug_app_freertos.slcp
+++ b/slc/apps/onoff_plug_app/wifi/matter_wifi_soc_onoff_plug_app_freertos.slcp
@@ -59,7 +59,7 @@ component:
   - id: wifi_resources
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: sl_si91x_common_flash_nvm3
+  - id: sl_si91x_common_flash_nvm3
   - id: sl_si91x_wireless
   - id: wifi
   - id: basic_network_config_manager

--- a/slc/apps/onoff_plug_app/wifi/matter_wifi_soc_onoff_plug_app_freertos.slcp
+++ b/slc/apps/onoff_plug_app/wifi/matter_wifi_soc_onoff_plug_app_freertos.slcp
@@ -59,8 +59,7 @@ component:
   - id: wifi_resources
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: sl_si91x_common_flash_nvm3
+    - id: sl_si91x_common_flash_nvm3
   - id: sl_si91x_wireless
   - id: wifi
   - id: basic_network_config_manager

--- a/slc/apps/oven_app/wifi/matter_wifi_soc_oven_app_freertos.slcp
+++ b/slc/apps/oven_app/wifi/matter_wifi_soc_oven_app_freertos.slcp
@@ -40,7 +40,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_on_off
+  - id: matter_on_off
   - id: matter_temperature_control
   - id: matter_temperature_measurement
   - id: matter_oven

--- a/slc/apps/oven_app/wifi/matter_wifi_soc_oven_app_freertos.slcp
+++ b/slc/apps/oven_app/wifi/matter_wifi_soc_oven_app_freertos.slcp
@@ -40,8 +40,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_on_off
+    - id: matter_on_off
   - id: matter_temperature_control
   - id: matter_temperature_measurement
   - id: matter_oven

--- a/slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_freertos.slcp
+++ b/slc/apps/performance_test_app/thread/matter_thread_soc_performance_test_app_freertos.slcp
@@ -63,8 +63,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  # Generate additional ZAP content for custom clusters
+    # Generate additional ZAP content for custom clusters
   - id: matter_zap_custom_generation
 
 requires:

--- a/slc/apps/platform_template/thread/matter_thread_soc_platform_template_freertos.slcp
+++ b/slc/apps/platform_template/thread/matter_thread_soc_platform_template_freertos.slcp
@@ -49,8 +49,7 @@ component:
   - id: matter_thread_network_diagnostics
   - id: matter_time_format_localization
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-    # ICD configurations
+      # ICD configurations
   - id: matter_test_event_trigger
     condition: [matter_icd_core]
   - id: matter_icd_checkin_sender

--- a/slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp
+++ b/slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp
@@ -47,7 +47,7 @@ component:
   - id: matter_platform_template
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_lwip
+  - id: matter_lwip
     # ICD configurations
   - id: matter_test_event_trigger
     condition: [matter_icd_core]

--- a/slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp
+++ b/slc/apps/platform_template/wifi/matter_wifi_soc_platform_template_freertos.slcp
@@ -47,8 +47,7 @@ component:
   - id: matter_platform_template
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_lwip
+    - id: matter_lwip
     # ICD configurations
   - id: matter_test_event_trigger
     condition: [matter_icd_core]

--- a/slc/apps/rangehood_app/thread/matter_thread_soc_rangehood_app_freertos.slcp
+++ b/slc/apps/rangehood_app/thread/matter_thread_soc_rangehood_app_freertos.slcp
@@ -57,8 +57,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
 requires:
   - name: matter_drivers_series_2
     condition:

--- a/slc/apps/rangehood_app/wifi/matter_wifi_soc_rangehood_app_freertos.slcp
+++ b/slc/apps/rangehood_app/wifi/matter_wifi_soc_rangehood_app_freertos.slcp
@@ -47,7 +47,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_on_off
+  - id: matter_on_off
   - id: matter_fan_control
   
   - id: matter_ota_requestor

--- a/slc/apps/rangehood_app/wifi/matter_wifi_soc_rangehood_app_freertos.slcp
+++ b/slc/apps/rangehood_app/wifi/matter_wifi_soc_rangehood_app_freertos.slcp
@@ -47,8 +47,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_on_off
+    - id: matter_on_off
   - id: matter_fan_control
   
   - id: matter_ota_requestor

--- a/slc/apps/refrigerator_app/thread/matter_thread_soc_refrigerator_app_freertos.slcp
+++ b/slc/apps/refrigerator_app/thread/matter_thread_soc_refrigerator_app_freertos.slcp
@@ -55,8 +55,7 @@ component:
   - id: matter_default_lcd_config
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
 requires:
   # On Series 2 LCD and external flash run over USART, VCOM runs over EUSART
   # Select UART/EUART drivers based on device series

--- a/slc/apps/refrigerator_app/wifi/matter_wifi_soc_refrigerator_app_freertos.slcp
+++ b/slc/apps/refrigerator_app/wifi/matter_wifi_soc_refrigerator_app_freertos.slcp
@@ -45,8 +45,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_ota_requestor
   - id: matter_ota_support
   - id: matter_shell

--- a/slc/apps/thermostat/thread/matter_thread_soc_thermostat_freertos.slcp
+++ b/slc/apps/thermostat/thread/matter_thread_soc_thermostat_freertos.slcp
@@ -56,8 +56,7 @@ component:
 
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   # Matter Zigbee Components
   - instance: [example]
     id: cli

--- a/slc/apps/thermostat/wifi/matter_wifi_917_ncp_thermostat_freertos.slcp
+++ b/slc/apps/thermostat/wifi/matter_wifi_917_ncp_thermostat_freertos.slcp
@@ -62,8 +62,7 @@ component:
   - id: matter_wifi_network_diagnostics
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_shell
   - id: matter_log_uart
   - id: matter_lwip

--- a/slc/apps/thermostat/wifi/matter_wifi_soc_thermostat_freertos.slcp
+++ b/slc/apps/thermostat/wifi/matter_wifi_soc_thermostat_freertos.slcp
@@ -58,8 +58,7 @@ component:
 
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  #  - id: i2cspm
+    #  - id: i2cspm
   #    instance: [sensor]
   
   - id: wifi_resources  

--- a/slc/apps/window_app/thread/matter_thread_soc_window_app_freertos.slcp
+++ b/slc/apps/window_app/thread/matter_thread_soc_window_app_freertos.slcp
@@ -61,8 +61,7 @@ component:
 
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_icd_core
+    - id: matter_icd_core
   - id: matter_test_event_trigger
   - id: matter_icd_management
   - id: matter_log_uart

--- a/slc/apps/window_app/thread/matter_thread_soc_window_app_freertos.slcp
+++ b/slc/apps/window_app/thread/matter_thread_soc_window_app_freertos.slcp
@@ -61,7 +61,7 @@ component:
 
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_icd_core
+  - id: matter_icd_core
   - id: matter_test_event_trigger
   - id: matter_icd_management
   - id: matter_log_uart

--- a/slc/apps/window_app/wifi/matter_wifi_917_ncp_window_app_freertos.slcp
+++ b/slc/apps/window_app/wifi/matter_wifi_917_ncp_window_app_freertos.slcp
@@ -65,8 +65,7 @@ component:
   - id: matter_window_covering
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-
+  
   - id: matter_shell
   - id: matter_icd_core
   - id: matter_test_event_trigger

--- a/slc/apps/window_app/wifi/matter_wifi_soc_window_app_freertos.slcp
+++ b/slc/apps/window_app/wifi/matter_wifi_soc_window_app_freertos.slcp
@@ -53,7 +53,7 @@ component:
   - id: matter_window_covering
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-    - id: matter_window
+  - id: matter_window
   - id: matter_shell
   - id: matter_default_lcd_config
     # ICD configurations

--- a/slc/apps/window_app/wifi/matter_wifi_soc_window_app_freertos.slcp
+++ b/slc/apps/window_app/wifi/matter_wifi_soc_window_app_freertos.slcp
@@ -53,8 +53,7 @@ component:
   - id: matter_window_covering
   # Override configuration for JTAG use
   - id: matter_configuration_over_swo
-  - id: segger_rtt
-  - id: matter_window
+    - id: matter_window
   - id: matter_shell
   - id: matter_default_lcd_config
     # ICD configurations

--- a/slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_freertos.slcp
+++ b/slc/apps/zigbee_light/thread/matter_thread_soc_zigbee_light_freertos.slcp
@@ -15,8 +15,7 @@ component:
   - instance: [example]
     id: cli
   - id: iostream_stdio
-  - id: segger_rtt
-  #Zigbee Components
+    #Zigbee Components
   - id: zigbee_ble_dmp_cli
   - id: zigbee_address_table
   - id: zigbee_application_bootloader

--- a/slc/component/matter-platform/device-attestation-credentials/matter_provision_default.slcc
+++ b/slc/component/matter-platform/device-attestation-credentials/matter_provision_default.slcc
@@ -17,8 +17,6 @@ config_file:
     file_id: matter_provision_config
 
 requires:
-  - name: iostream
-  - name: iostream_rtt
   - name: matter_crypto_psa_siwx917 # Provisioning Default only support PSA crypto flavor
     condition: [device_family_siwg917]
 

--- a/slc/component/matter-platform/device-attestation-credentials/matter_provision_flash.slcc
+++ b/slc/component/matter-platform/device-attestation-credentials/matter_provision_flash.slcc
@@ -12,8 +12,6 @@ provides:
   - name: matter_provision_flash
 
 requires:
-  - name: iostream
-  - name: iostream_rtt
   - name: matter_crypto_siwx917
     condition: [device_family_siwg917]
 

--- a/slc/component/matter-platform/logging/matter_log_rtt.slcc
+++ b/slc/component/matter-platform/logging/matter_log_rtt.slcc
@@ -9,6 +9,8 @@ metadata:
     license: Zlib
 provides:
   - name: matter_log_rtt
+requires:
+  - name: segger_rtt
 define:
   - name: SILABS_LOG_OUT_UART
     value: 0


### PR DESCRIPTION
**Issue Link:** 
MATTER-4906 

**Description of Problem/Feature:**
One of our customers wants to builds without SEGGER as a dependencies since the EU requires manufacturer to list all third_party software present in their products.

**Description of Fix/Solution:**
As discussed with @rcasallas-silabs we shouldn't need SEGGER inside the application binaries once provisioning is done.

**Testing Done:**
CI will validate behaviour but lighting-app builds locally.