### PR TITLE
Add cancel-in-progress to jenkins polling job

### DIFF
--- a/.github/workflows/dev-apps-builder.yaml
+++ b/.github/workflows/dev-apps-builder.yaml
@@ -291,9 +291,6 @@ jobs:
             - merge-apps
             - build_coverage
         if: ${{ always() && needs.merge-apps.result == 'success' && needs.build_coverage.result != 'failure' }}
-        concurrency:
-            group: dev-build-examples-${{ github.ref }}
-            cancel-in-progress: true
         uses: ./.github/workflows/sqa-sanity-tests.yaml
         secrets:
             SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/dev-apps-builder.yaml
+++ b/.github/workflows/dev-apps-builder.yaml
@@ -290,7 +290,10 @@ jobs:
         needs: 
             - merge-apps
             - build_coverage
-        if: ${{ always() && needs.merge-apps.result == 'success' && needs.build_coverage.result != 'failure' }}        
+        if: ${{ always() && needs.merge-apps.result == 'success' && needs.build_coverage.result != 'failure' }}
+        concurrency:
+            group: dev-build-examples-${{ github.ref }}
+            cancel-in-progress: true
         uses: ./.github/workflows/sqa-sanity-tests.yaml
         secrets:
             SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY: ${{ secrets.SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/sqa-sanity-tests.yaml
+++ b/.github/workflows/sqa-sanity-tests.yaml
@@ -7,7 +7,7 @@ on:
                 required: true
 
 concurrency:
-    group: dev-build-examples-${{ github.ref }}
+    group: dev-build-wait-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/sqa-sanity-tests.yaml
+++ b/.github/workflows/sqa-sanity-tests.yaml
@@ -6,6 +6,10 @@ on:
             SILABSSW_MATTER_CI_BOT_APP_PRIVATE_KEY:
                 required: true
 
+concurrency:
+    group: dev-build-examples-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   wait-for-jenkins-status:
       name: Wait for Jenkins Status


### PR DESCRIPTION
**Issue Link:** 
NOJIRA 

**Description of Problem/Feature:**
Once PR CI reaches stage of waiting for jenkins results, if another commit is pushed to PR the in progress job does not cancel (which is what dev-apps-builder is set to do). this is because the reusable sqa-sanity-tests job does not have concurrency set 

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
add `cancel-in-progress` concurrency groups to `sqa-sanity-tests.yaml` toreliably cancel on new run

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
In this PR, once we reach wait for test results stage will push an empty test commit to validate job cancellation