### PR TITLE
Remove duplicated determine_compiler

### DIFF
--- a/jenkins_integration/jenkinsFunctions.groovy
+++ b/jenkins_integration/jenkinsFunctions.groovy
@@ -100,15 +100,6 @@ def run_code_size_analysis() {
                     fi
                 }
 
-                determine_compiler() {
-                    local path=$1
-                    if [[ "$path" == *"_solution_llvm"* ]]; then
-                        echo "llvm"
-                    else
-                        echo "gcc"
-                    fi
-                }
-
                 perform_code_analysis() {
                     local map_file_path=$1
 


### PR DESCRIPTION
<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
n/a

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Minor issue where merge actions created a duplicate determine_compiler function

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Remove the extra implementation of determine_compiler. It is already there just above.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
ci. There was no ill effect since it was twice the same implementation.