### PR TITLE
Provision components updated for build with clang.

### DIFF
--- a/slc/component/matter-platform/device-attestation-credentials/matter_provision_default.slcc
+++ b/slc/component/matter-platform/device-attestation-credentials/matter_provision_default.slcc
@@ -77,9 +77,19 @@ library:
       - device_family_mgm26
     unless:
       - toolchain_llvm
+  - path: third_party/matter_support/provision/libs/libProvision-efr32mg26-clang.a
+    condition:
+      - device_family_mgm26
+      - toolchain_llvm
   - path: third_party/matter_support/provision/libs/libProvisionPSA-si917.a
     condition:
       - device_family_siwg917
+    unless:
+      - toolchain_llvm
+  - path: third_party/matter_support/provision/libs/libProvisionPSA-si917-clang.a
+    condition:
+      - device_family_siwg917
+      - toolchain_llvm
   - path: third_party/matter_support/provision/libs/libProvision-efr32mg24.a
     condition:
       - device_family_simg301

--- a/slc/component/matter-platform/device-attestation-credentials/matter_provision_flash.slcc
+++ b/slc/component/matter-platform/device-attestation-credentials/matter_provision_flash.slcc
@@ -47,23 +47,61 @@ library:
   - path: third_party/matter_support/provision/libs/libProvisionFlash-efr32mg24.a
     condition:
       - device_family_efr32mg24
+    unless:
+      - toolchain_llvm
+  - path: third_party/matter_support/provision/libs/libProvisionFlash-efr32mg24-clang.a
+    condition:
+      - device_family_efr32mg24
+      - toolchain_llvm
   - path: third_party/matter_support/provision/libs/libProvisionFlash-efr32mg26.a
     condition:
       - device_family_efr32mg26
+    unless:
+      - toolchain_llvm
+  - path: third_party/matter_support/provision/libs/libProvisionFlash-efr32mg26-clang.a
+    condition:
+      - device_family_efr32mg26
+      - toolchain_llvm
   - path: third_party/matter_support/provision/libs/libProvisionFlash-mgm24.a
     condition:
       - device_family_mgm24
+    unless:
+      - toolchain_llvm
+  - path: third_party/matter_support/provision/libs/libProvisionFlash-mgm24-clang.a
+    condition:
+      - device_family_mgm24
+      - toolchain_llvm
   - path: third_party/matter_support/provision/libs/libProvisionFlash-efr32mg26.a
     condition:
       - device_family_mgm26
+    unless:
+      - toolchain_llvm
+  - path: third_party/matter_support/provision/libs/libProvisionFlash-efr32mg26-clang.a
+    condition:
+      - device_family_mgm26
+      - toolchain_llvm
   - path: third_party/matter_support/provision/libs/libProvision-si917.a
     condition:
       - device_family_siwg917
       - matter_crypto_tinycrypt_siwx917
+    unless:
+      - toolchain_llvm
+  - path: third_party/matter_support/provision/libs/libProvision-si917-clang.a
+    condition:
+      - device_family_siwg917
+      - matter_crypto_tinycrypt_siwx917
+      - toolchain_llvm
   - path: third_party/matter_support/provision/libs/libProvisionPSA-si917.a
     condition:
       - device_family_siwg917
       - matter_crypto_psa_siwx917
+    unless:
+      - toolchain_llvm
+  - path: third_party/matter_support/provision/libs/libProvisionPSA-si917-clang.a
+    condition:
+      - device_family_siwg917
+      - matter_crypto_psa_siwx917
+      - toolchain_llvm
 
 template_contribution:
   # Series-3 will use common token manager.


### PR DESCRIPTION
<!-- Please fill out all sections below. Lines starting with <!-- are comments and will not be visible in the final PR.
-->

<!-- Issue Link: Reference the Issue this PR addresses -->
**Issue Link:** 
[MATTER-6757](https://jira.silabs.com/browse/MATTER-6757).

<!-- Briefly describe the problem or feature addressed by this PR.-->
**Description of Problem/Feature:**
Missing clang provision libraries for 917.

<!-- Clearly explain the solution or fix implemented in this PR. -->
**Description of Fix/Solution:**
Matter support updated. to latest `release_2.9-1.6`.

<!-- Describe what testing was performed to validate these changes.
  If no testing was done, explain why. -->
**Testing Done:**
Verified that missing provision libraries are now included.